### PR TITLE
feat: `removeIndent` util for CSS code blocks

### DIFF
--- a/pages/accordion/index.tsx
+++ b/pages/accordion/index.tsx
@@ -9,6 +9,7 @@ import Block from '../../placeholders/Block';
 import BrowserFrame from '../../placeholders/BrowserFrame';
 import Rectangle from '../../placeholders/Rectangle';
 import Triangle from '../../placeholders/Triangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 interface ItemProps {
     index: number;
@@ -87,7 +88,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .accordion {
                         /* Border */
                         border: 1px solid rgba(0, 0, 0, 0.3);

--- a/pages/arrow-buttons/index.tsx
+++ b/pages/arrow-buttons/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -251,7 +251,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CloseButton, Pattern.PopoverArrow, Pattern.TriangleButtons]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/arrow-buttons/index.tsx
+++ b/pages/arrow-buttons/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -54,7 +55,7 @@ const Details: React.FC<{}> = () => {
     ...
 </button>
 `}
-                css={`
+                css={removeIndent`
                     .button {
                         /* Center the content */
                         align-items: center;
@@ -250,7 +251,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CloseButton, Pattern.PopoverArrow, Pattern.TriangleButtons]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/avatar-list/index.tsx
+++ b/pages/avatar-list/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Avatar: React.FC<{}> = ({ children }) => {
     return (
@@ -24,8 +25,8 @@ const Avatar: React.FC<{}> = ({ children }) => {
         >
             {children}
         </div>
-    );
-};
+    )
+}
 
 const Details: React.FC<{}> = () => {
     return (
@@ -51,7 +52,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .avatars {
                         display: flex;
                     }
@@ -108,7 +109,7 @@ const Details: React.FC<{}> = () => {
                 patterns={[Pattern.Avatar, Pattern.Centering, Pattern.InitialAvatar, Pattern.PresenceIndicator]}
             />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/avatar-list/index.tsx
+++ b/pages/avatar-list/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Avatar: React.FC<{}> = ({ children }) => {
     return (
@@ -25,8 +25,8 @@ const Avatar: React.FC<{}> = ({ children }) => {
         >
             {children}
         </div>
-    )
-}
+    );
+};
 
 const Details: React.FC<{}> = () => {
     return (
@@ -109,7 +109,7 @@ const Details: React.FC<{}> = () => {
                 patterns={[Pattern.Avatar, Pattern.Centering, Pattern.InitialAvatar, Pattern.PresenceIndicator]}
             />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/avatar/index.tsx
+++ b/pages/avatar/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -85,7 +85,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.AvatarList, Pattern.InitialAvatar, Pattern.PresenceIndicator]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/avatar/index.tsx
+++ b/pages/avatar/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -23,7 +24,7 @@ const Details: React.FC<{}> = () => {
     <img class="avatar__image" src="..." />
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .avatar {
                         /* Rounded border */
                         border-radius: 50%;
@@ -84,7 +85,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.AvatarList, Pattern.InitialAvatar, Pattern.PresenceIndicator]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/badge/index.tsx
+++ b/pages/badge/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -73,7 +73,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Centering, Pattern.InitialAvatar]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/badge/index.tsx
+++ b/pages/badge/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -22,7 +23,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .badge {
                         /* Center the content */
                         align-items: center;
@@ -72,7 +73,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Centering, Pattern.InitialAvatar]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/breadcrumb/index.tsx
+++ b/pages/breadcrumb/index.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -28,7 +29,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .breadcrumb {
                         /* Content is centered vertically */
                         align-items: center;
@@ -70,7 +71,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/breadcrumb/index.tsx
+++ b/pages/breadcrumb/index.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -71,7 +71,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/button-with-icon/index.tsx
+++ b/pages/button-with-icon/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -26,7 +27,7 @@ const Details: React.FC<{}> = () => {
     ...
 </button>
 `}
-                css={`
+                css={removeIndent`
                     .button {
                         /* Center the content */
                         align-items: center;
@@ -67,7 +68,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/button-with-icon/index.tsx
+++ b/pages/button-with-icon/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -68,7 +68,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/card-layout/index.tsx
+++ b/pages/card-layout/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -29,7 +30,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .cards {
                         display: flex;
 
@@ -77,7 +78,7 @@ const Details: React.FC<{}> = () => {
                                     >
                                         <Rectangle height={80} />
                                     </div>
-                                );
+                                )
                             })}
                     </div>
                 </div>
@@ -86,7 +87,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Card, Pattern.MasonryGrid, Pattern.SimpleGrid]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/card-layout/index.tsx
+++ b/pages/card-layout/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -78,7 +78,7 @@ const Details: React.FC<{}> = () => {
                                     >
                                         <Rectangle height={80} />
                                     </div>
-                                )
+                                );
                             })}
                     </div>
                 </div>
@@ -87,7 +87,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Card, Pattern.MasonryGrid, Pattern.SimpleGrid]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/card/index.tsx
+++ b/pages/card/index.tsx
@@ -1,13 +1,14 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -33,7 +34,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .card {
                         display: flex;
                         flex-direction: column;
@@ -87,7 +88,7 @@ const Details: React.FC<{}> = () => {
                 patterns={[Pattern.CardLayout, Pattern.LayeredCard, Pattern.StackedCards, Pattern.ThreeDimensionsCard]}
             />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/card/index.tsx
+++ b/pages/card/index.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -88,7 +88,7 @@ const Details: React.FC<{}> = () => {
                 patterns={[Pattern.CardLayout, Pattern.LayeredCard, Pattern.StackedCards, Pattern.ThreeDimensionsCard]}
             />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/centering/index.tsx
+++ b/pages/centering/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -54,7 +54,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/centering/index.tsx
+++ b/pages/centering/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -22,7 +23,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         align-items: center;
                         display: flex;
@@ -53,7 +54,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/chip/index.tsx
+++ b/pages/chip/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import Link from 'next/link'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const InputChip: React.FC<{}> = ({ children }) => {
     return (
@@ -56,8 +56,8 @@ const InputChip: React.FC<{}> = ({ children }) => {
                 />
             </button>
         </div>
-    )
-}
+    );
+};
 
 const Details: React.FC<{}> = () => {
     return (
@@ -126,7 +126,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CloseButton]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/chip/index.tsx
+++ b/pages/chip/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import Link from 'next/link';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const InputChip: React.FC<{}> = ({ children }) => {
     return (
@@ -55,8 +56,8 @@ const InputChip: React.FC<{}> = ({ children }) => {
                 />
             </button>
         </div>
-    );
-};
+    )
+}
 
 const Details: React.FC<{}> = () => {
     return (
@@ -87,7 +88,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .chip {
                         /* Center the content */
                         align-items: center;
@@ -125,7 +126,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CloseButton]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/circular-navigation/index.tsx
+++ b/pages/circular-navigation/index.tsx
@@ -1,13 +1,14 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Square from '../../placeholders/Square';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Square from '../../placeholders/Square'
+import { removeIndent } from '../../utils/removeIndent'
 
 interface CircularItemProps {
-    degree: number;
+    degree: number
 }
 
 const CircularItem: React.FC<CircularItemProps> = ({ degree, children }) => {
@@ -37,11 +38,11 @@ const CircularItem: React.FC<CircularItemProps> = ({ degree, children }) => {
                 {children}
             </div>
         </div>
-    );
-};
+    )
+}
 
 const Details: React.FC<{}> = () => {
-    const numItems = 6;
+    const numItems = 6
 
     return (
         <PatternLayout pattern={Pattern.CircularNavigation}>
@@ -69,7 +70,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .navigation {
                         position: relative;
                     }
@@ -133,13 +134,13 @@ const Details: React.FC<{}> = () => {
                                     <CircularItem key={i} degree={(360 / numItems) * i}>
                                         {i + 1}
                                     </CircularItem>
-                                );
+                                )
                             })}
                     </div>
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/circular-navigation/index.tsx
+++ b/pages/circular-navigation/index.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Square from '../../placeholders/Square'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Square from '../../placeholders/Square';
+import { removeIndent } from '../../utils/removeIndent';
 
 interface CircularItemProps {
-    degree: number
+    degree: number;
 }
 
 const CircularItem: React.FC<CircularItemProps> = ({ degree, children }) => {
@@ -38,11 +38,11 @@ const CircularItem: React.FC<CircularItemProps> = ({ degree, children }) => {
                 {children}
             </div>
         </div>
-    )
-}
+    );
+};
 
 const Details: React.FC<{}> = () => {
-    const numItems = 6
+    const numItems = 6;
 
     return (
         <PatternLayout pattern={Pattern.CircularNavigation}>
@@ -134,13 +134,13 @@ const Details: React.FC<{}> = () => {
                                     <CircularItem key={i} degree={(360 / numItems) * i}>
                                         {i + 1}
                                     </CircularItem>
-                                )
+                                );
                             })}
                     </div>
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/close-button/index.tsx
+++ b/pages/close-button/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -24,7 +25,7 @@ const Details: React.FC<{}> = () => {
     <div class="button__line button__line--second"></div>
 </button>
 `}
-                css={`
+                css={removeIndent`
                     .button {
                         /* Reset */
                         background-color: transparent;
@@ -125,7 +126,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.ArrowButtons, Pattern.Chip, Pattern.Modal, Pattern.Notification]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/close-button/index.tsx
+++ b/pages/close-button/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -126,7 +126,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.ArrowButtons, Pattern.Chip, Pattern.Modal, Pattern.Notification]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/color-swatch/index.tsx
+++ b/pages/color-swatch/index.tsx
@@ -1,9 +1,10 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -23,7 +24,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .swatch {
                         /* Wrap the items */
                         display: flex;
@@ -73,7 +74,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/color-swatch/index.tsx
+++ b/pages/color-swatch/index.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -74,7 +74,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/concave-corners/index.tsx
+++ b/pages/concave-corners/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -129,7 +129,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.InvertedCorners]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/concave-corners/index.tsx
+++ b/pages/concave-corners/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -35,7 +36,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     :root {
                         --concave-corners-background: rgba(0, 0, 0, 0.3);
                         --concave-corners-size: 1rem;
@@ -128,7 +129,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.InvertedCorners]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/cookie-banner/index.tsx
+++ b/pages/cookie-banner/index.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -87,7 +87,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.FixedAtCorner]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/cookie-banner/index.tsx
+++ b/pages/cookie-banner/index.tsx
@@ -1,13 +1,14 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -30,7 +31,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .banner {
                         /* Banner is displayed at the bottom */
                         bottom: 0;
@@ -86,7 +87,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.FixedAtCorner]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/corner-ribbon/index.tsx
+++ b/pages/corner-ribbon/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import Link from 'next/link'
-import { Heading, Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { Heading, Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -199,7 +199,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.FixedAtCorner, Pattern.Ribbon]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/corner-ribbon/index.tsx
+++ b/pages/corner-ribbon/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import Link from 'next/link';
-import { Heading, Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import { Heading, Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -29,7 +30,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         position: relative;
                     }
@@ -198,7 +199,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.FixedAtCorner, Pattern.Ribbon]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/curved-background/index.tsx
+++ b/pages/curved-background/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -58,7 +58,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.DiagonalSection]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/curved-background/index.tsx
+++ b/pages/curved-background/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -22,7 +23,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Background color */
                         background-color: rgba(0, 0, 0, 0.3);
@@ -57,7 +58,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.DiagonalSection]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/custom-checkbox-button/index.tsx
+++ b/pages/custom-checkbox-button/index.tsx
@@ -1,23 +1,23 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 interface CheckboxProps {
-    isChecked: boolean
-    value: string
+    isChecked: boolean;
+    value: string;
 }
 
 const Details: React.FC<{}> = () => {
     const Checkbox: React.FC<CheckboxProps> = ({ isChecked, value, children }) => {
-        const [checked, setChecked] = React.useState(isChecked)
-        const click = () => setChecked((c) => !c)
+        const [checked, setChecked] = React.useState(isChecked);
+        const click = () => setChecked((c) => !c);
 
         return (
             <label
@@ -56,8 +56,8 @@ const Details: React.FC<{}> = () => {
                 </div>
                 {children}
             </label>
-        )
-    }
+        );
+    };
 
     return (
         <PatternLayout pattern={Pattern.CustomCheckboxButton}>
@@ -174,7 +174,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CustomRadioButton, Pattern.RadioButtonGroup]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/custom-checkbox-button/index.tsx
+++ b/pages/custom-checkbox-button/index.tsx
@@ -1,22 +1,23 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 interface CheckboxProps {
-    isChecked: boolean;
-    value: string;
+    isChecked: boolean
+    value: string
 }
 
 const Details: React.FC<{}> = () => {
     const Checkbox: React.FC<CheckboxProps> = ({ isChecked, value, children }) => {
-        const [checked, setChecked] = React.useState(isChecked);
-        const click = () => setChecked((c) => !c);
+        const [checked, setChecked] = React.useState(isChecked)
+        const click = () => setChecked((c) => !c)
 
         return (
             <label
@@ -55,8 +56,8 @@ const Details: React.FC<{}> = () => {
                 </div>
                 {children}
             </label>
-        );
-    };
+        )
+    }
 
     return (
         <PatternLayout pattern={Pattern.CustomCheckboxButton}>
@@ -82,7 +83,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .label {
                         /* Center the content horizontally */
                         align-items: center;
@@ -173,7 +174,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CustomRadioButton, Pattern.RadioButtonGroup]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/custom-radio-button/index.tsx
+++ b/pages/custom-radio-button/index.tsx
@@ -1,23 +1,23 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 interface RadioProps {
-    value: string
+    value: string;
 }
 
 const Details: React.FC<{}> = () => {
-    const [selectedValue, setSelectedValue] = React.useState('1')
+    const [selectedValue, setSelectedValue] = React.useState('1');
 
     const Radio: React.FC<RadioProps> = ({ value, children }) => {
-        const click = () => setSelectedValue(value)
+        const click = () => setSelectedValue(value);
 
         return (
             <label
@@ -55,8 +55,8 @@ const Details: React.FC<{}> = () => {
                 </div>
                 {children}
             </label>
-        )
-    }
+        );
+    };
 
     return (
         <PatternLayout pattern={Pattern.CustomRadioButton}>
@@ -177,7 +177,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CustomCheckboxButton, Pattern.RadioButtonGroup]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/custom-radio-button/index.tsx
+++ b/pages/custom-radio-button/index.tsx
@@ -1,22 +1,23 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 interface RadioProps {
-    value: string;
+    value: string
 }
 
 const Details: React.FC<{}> = () => {
-    const [selectedValue, setSelectedValue] = React.useState('1');
+    const [selectedValue, setSelectedValue] = React.useState('1')
 
     const Radio: React.FC<RadioProps> = ({ value, children }) => {
-        const click = () => setSelectedValue(value);
+        const click = () => setSelectedValue(value)
 
         return (
             <label
@@ -54,8 +55,8 @@ const Details: React.FC<{}> = () => {
                 </div>
                 {children}
             </label>
-        );
-    };
+        )
+    }
 
     return (
         <PatternLayout pattern={Pattern.CustomRadioButton}>
@@ -81,7 +82,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .label {
                         /* Center the content horizontally */
                         align-items: center;
@@ -176,7 +177,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CustomCheckboxButton, Pattern.RadioButtonGroup]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/diagonal-section/index.tsx
+++ b/pages/diagonal-section/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -96,7 +96,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CurvedBackground]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/diagonal-section/index.tsx
+++ b/pages/diagonal-section/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -27,7 +28,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Used to position the diagonal area */
                         position: relative;
@@ -95,7 +96,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CurvedBackground]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/docked-at-corner/index.tsx
+++ b/pages/docked-at-corner/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Heading, Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Heading, Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -28,7 +29,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         position: relative;
                     }
@@ -155,7 +156,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.PresenceIndicator]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/docked-at-corner/index.tsx
+++ b/pages/docked-at-corner/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Heading, Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Heading, Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -156,7 +156,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.PresenceIndicator]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/dot-leader/index.tsx
+++ b/pages/dot-leader/index.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Heading, Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Heading, Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -176,7 +176,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Menu, Pattern.PropertyList, Pattern.SplitNavigation]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/dot-leader/index.tsx
+++ b/pages/dot-leader/index.tsx
@@ -1,13 +1,14 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Heading, Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Heading, Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -31,7 +32,7 @@ const Details: React.FC<{}> = () => {
     <div>...</div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Center the content */
                         align-items: center;
@@ -175,7 +176,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Menu, Pattern.PropertyList, Pattern.SplitNavigation]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/dot-navigation/index.tsx
+++ b/pages/dot-navigation/index.tsx
@@ -1,21 +1,21 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 interface DotProps {
-    index: number
+    index: number;
 }
 
 const Details: React.FC<{}> = () => {
-    const [activeItem, setActiveItem] = React.useState(0)
+    const [activeItem, setActiveItem] = React.useState(0);
 
     const Dot: React.FC<DotProps> = ({ index }) => {
-        const isActive = index === activeItem
-        const click = () => setActiveItem(index)
+        const isActive = index === activeItem;
+        const click = () => setActiveItem(index);
         return (
             <li
                 style={{
@@ -29,8 +29,8 @@ const Details: React.FC<{}> = () => {
                 }}
                 onClick={click}
             />
-        )
-    }
+        );
+    };
 
     return (
         <PatternLayout pattern={Pattern.DotNavigation}>
@@ -108,7 +108,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/dot-navigation/index.tsx
+++ b/pages/dot-navigation/index.tsx
@@ -1,20 +1,21 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 interface DotProps {
-    index: number;
+    index: number
 }
 
 const Details: React.FC<{}> = () => {
-    const [activeItem, setActiveItem] = React.useState(0);
+    const [activeItem, setActiveItem] = React.useState(0)
 
     const Dot: React.FC<DotProps> = ({ index }) => {
-        const isActive = index === activeItem;
-        const click = () => setActiveItem(index);
+        const isActive = index === activeItem
+        const click = () => setActiveItem(index)
         return (
             <li
                 style={{
@@ -28,8 +29,8 @@ const Details: React.FC<{}> = () => {
                 }}
                 onClick={click}
             />
-        );
-    };
+        )
+    }
 
     return (
         <PatternLayout pattern={Pattern.DotNavigation}>
@@ -48,7 +49,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .dots {
                         /* Center the content */
                         align-items: center;
@@ -107,7 +108,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/drawer/index.tsx
+++ b/pages/drawer/index.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -101,7 +101,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/drawer/index.tsx
+++ b/pages/drawer/index.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -28,7 +29,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Container takes full size */
                         height: 100%;
@@ -100,7 +101,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/drop-area/index.tsx
+++ b/pages/drop-area/index.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -63,7 +63,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/drop-area/index.tsx
+++ b/pages/drop-area/index.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -63,7 +63,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/drop-cap/index.tsx
+++ b/pages/drop-cap/index.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { Pattern } from '../../constants/Pattern'
-import { removeIndent } from '../../utils/removeIndent'
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -58,7 +58,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/drop-cap/index.tsx
+++ b/pages/drop-cap/index.tsx
@@ -1,9 +1,10 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { Pattern } from '../../constants/Pattern'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -20,7 +21,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     /* Styles for the first letter */
                     .container:first-letter {
                         /* Display at the left */
@@ -57,7 +58,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/dropdown/index.tsx
+++ b/pages/dropdown/index.tsx
@@ -1,15 +1,15 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import Triangle from '../../placeholders/Triangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import Triangle from '../../placeholders/Triangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -139,7 +139,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.MegaMenu, Pattern.Menu, Pattern.NestedDropdowns]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/dropdown/index.tsx
+++ b/pages/dropdown/index.tsx
@@ -1,14 +1,15 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
-import Triangle from '../../placeholders/Triangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import Triangle from '../../placeholders/Triangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -34,7 +35,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .dropdown {
                         position: relative;
                     }
@@ -138,7 +139,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.MegaMenu, Pattern.Menu, Pattern.NestedDropdowns]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/fading-long-section/index.tsx
+++ b/pages/fading-long-section/index.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Pattern } from '../../constants/Pattern';
+import * as React from 'react'
+import Head from 'next/head'
+import { Pattern } from '../../constants/Pattern'
 
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -30,7 +31,7 @@ const Details: React.FC<{}> = () => {
     <div class="container__fading"></div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Used to position the faded element */
                         position: relative;
@@ -93,7 +94,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/fading-long-section/index.tsx
+++ b/pages/fading-long-section/index.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Pattern } from '../../constants/Pattern'
+import * as React from 'react';
+import Head from 'next/head';
+import { Pattern } from '../../constants/Pattern';
 
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -94,7 +94,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/feature-comparison/index.tsx
+++ b/pages/feature-comparison/index.tsx
@@ -1,15 +1,15 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -217,7 +217,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.FeatureList, Pattern.PricingTable]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/feature-comparison/index.tsx
+++ b/pages/feature-comparison/index.tsx
@@ -1,14 +1,15 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -43,7 +44,7 @@ const Details: React.FC<{}> = () => {
 <!-- Repeated items -->
 ...
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         align-items: center;
                         display: flex;
@@ -216,7 +217,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.FeatureList, Pattern.PricingTable]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/feature-list/index.tsx
+++ b/pages/feature-list/index.tsx
@@ -1,15 +1,15 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -96,7 +96,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.FeatureComparison]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/feature-list/index.tsx
+++ b/pages/feature-list/index.tsx
@@ -1,14 +1,15 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -37,7 +38,7 @@ const Details: React.FC<{}> = () => {
 <!-- Repeated items -->
 ...
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         display: flex;
 
@@ -95,7 +96,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.FeatureComparison]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/fixed-at-corner/index.tsx
+++ b/pages/fixed-at-corner/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Triangle from '../../placeholders/Triangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Triangle from '../../placeholders/Triangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -90,7 +90,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CookieBanner, Pattern.CornerRibbon, Pattern.FixedAtSide]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/fixed-at-corner/index.tsx
+++ b/pages/fixed-at-corner/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Triangle from '../../placeholders/Triangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Triangle from '../../placeholders/Triangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -41,7 +42,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         position: relative;
                     }
@@ -89,7 +90,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CookieBanner, Pattern.CornerRibbon, Pattern.FixedAtSide]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/fixed-at-side/index.tsx
+++ b/pages/fixed-at-side/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Heading, Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Heading, Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -259,7 +259,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.FixedAtCorner]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/fixed-at-side/index.tsx
+++ b/pages/fixed-at-side/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Heading, Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Heading, Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -23,7 +24,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         right: 0;
                         position: fixed;
@@ -258,7 +259,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.FixedAtCorner]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/floating-label/index.tsx
+++ b/pages/floating-label/index.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { Pattern } from '../../constants/Pattern'
-import { removeIndent } from '../../utils/removeIndent'
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -101,7 +101,7 @@ placeholder of input isn't shown
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/floating-label/index.tsx
+++ b/pages/floating-label/index.tsx
@@ -1,9 +1,10 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { Pattern } from '../../constants/Pattern'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -27,7 +28,7 @@ const Details: React.FC<{}> = () => {
     <label class="container__label">Placeholder</label>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         position: relative;
                     }
@@ -100,7 +101,7 @@ placeholder of input isn't shown
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/folder-structure/index.tsx
+++ b/pages/folder-structure/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Square from '../../placeholders/Square';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Square from '../../placeholders/Square'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -48,7 +49,7 @@ const Details: React.FC<{}> = () => {
     </ul>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     :root {
                         --folder-structure-item-height: 1rem;
                         --folder-structure-item-margin-left: 2rem;
@@ -165,7 +166,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.TreeDiagram]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/folder-structure/index.tsx
+++ b/pages/folder-structure/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Square from '../../placeholders/Square'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Square from '../../placeholders/Square';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -166,7 +166,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.TreeDiagram]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/full-background/index.tsx
+++ b/pages/full-background/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -23,7 +24,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Center the content */
                         align-items: center;
@@ -69,7 +70,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.VideoBackground]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/full-background/index.tsx
+++ b/pages/full-background/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -70,7 +70,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.VideoBackground]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/full-screen-menu/index.tsx
+++ b/pages/full-screen-menu/index.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -29,7 +30,7 @@ const Details: React.FC<{}> = () => {
     </ul>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Full screen overlay */
                         height: 100%;
@@ -134,7 +135,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/full-screen-menu/index.tsx
+++ b/pages/full-screen-menu/index.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -135,7 +135,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/holy-grail/index.tsx
+++ b/pages/holy-grail/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -37,7 +38,7 @@ const Details: React.FC<{}> = () => {
     </footer>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         display: flex;
                         flex-direction: column;
@@ -121,7 +122,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/holy-grail/index.tsx
+++ b/pages/holy-grail/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -122,7 +122,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/initial-avatar/index.tsx
+++ b/pages/initial-avatar/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import Link from 'next/link';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -33,7 +34,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .avatar {
                         /* Center the content */
                         display: inline-block;
@@ -110,7 +111,7 @@ const Details: React.FC<{}> = () => {
                 ]}
             />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/initial-avatar/index.tsx
+++ b/pages/initial-avatar/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import Link from 'next/link'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -111,7 +111,7 @@ const Details: React.FC<{}> = () => {
                 ]}
             />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/input-addon/index.tsx
+++ b/pages/input-addon/index.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -55,7 +56,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         display: flex;
 
@@ -201,7 +202,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/input-addon/index.tsx
+++ b/pages/input-addon/index.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -202,7 +202,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/inverted-corners/index.tsx
+++ b/pages/inverted-corners/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Heading, Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Heading, Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -22,7 +23,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     :root {
                         --inverted-corners-background: #52525b;
                         --inverted-corners-size: 2rem;
@@ -94,7 +95,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.ConcaveCorners]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/inverted-corners/index.tsx
+++ b/pages/inverted-corners/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Heading, Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Heading, Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -95,7 +95,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.ConcaveCorners]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/keyboard-shortcut/index.tsx
+++ b/pages/keyboard-shortcut/index.tsx
@@ -1,15 +1,16 @@
-import * as React from 'react';
-import Head from 'next/head';
-import Link from 'next/link';
-import { Heading, Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import { Heading, Spacer } from '@1milligram/design'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 interface ItemProps {
-    action: string;
-    keys: string;
+    action: string
+    keys: string
 }
 
 const Item: React.FC<ItemProps> = ({ action, keys }) => {
@@ -36,8 +37,8 @@ const Item: React.FC<ItemProps> = ({ action, keys }) => {
                 {keys}
             </kbd>
         </div>
-    );
-};
+    )
+}
 
 const Details: React.FC<{}> = () => {
     return (
@@ -57,7 +58,7 @@ const Details: React.FC<{}> = () => {
     ...
 </kbd>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Background and color */
                         background-color: rgba(0, 0, 0, 0.1);
@@ -116,7 +117,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </section>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/keyboard-shortcut/index.tsx
+++ b/pages/keyboard-shortcut/index.tsx
@@ -1,16 +1,16 @@
-import * as React from 'react'
-import Head from 'next/head'
-import Link from 'next/link'
-import { Heading, Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { Heading, Spacer } from '@1milligram/design';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 interface ItemProps {
-    action: string
-    keys: string
+    action: string;
+    keys: string;
 }
 
 const Item: React.FC<ItemProps> = ({ action, keys }) => {
@@ -37,8 +37,8 @@ const Item: React.FC<ItemProps> = ({ action, keys }) => {
                 {keys}
             </kbd>
         </div>
-    )
-}
+    );
+};
 
 const Details: React.FC<{}> = () => {
     return (
@@ -117,7 +117,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </section>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/layered-card/index.tsx
+++ b/pages/layered-card/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -22,7 +23,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .layered-card {
                         position: relative;
                     }
@@ -71,7 +72,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Card, Pattern.StackedCards, Pattern.ThreeDimensionsCard]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/layered-card/index.tsx
+++ b/pages/layered-card/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -72,7 +72,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Card, Pattern.StackedCards, Pattern.ThreeDimensionsCard]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/lined-paper/index.tsx
+++ b/pages/lined-paper/index.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -66,7 +66,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/lined-paper/index.tsx
+++ b/pages/lined-paper/index.tsx
@@ -1,9 +1,10 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -20,7 +21,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Lined background */
                         background-image: linear-gradient(rgba(0, 0, 0, 0.3) 1px, transparent 0px);
@@ -65,7 +66,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/masonry-grid/index.tsx
+++ b/pages/masonry-grid/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -26,7 +27,7 @@ const Details: React.FC<{}> = () => {
     <!-- Repeat other items -->
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .masonry-grid {
                         /* It is split into 3 columns */
                         column-count: 3;
@@ -95,7 +96,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CardLayout, Pattern.SimpleGrid]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/masonry-grid/index.tsx
+++ b/pages/masonry-grid/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -96,7 +96,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CardLayout, Pattern.SimpleGrid]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/media-object/index.tsx
+++ b/pages/media-object/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
-import Square from '../../placeholders/Square';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import Square from '../../placeholders/Square'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -31,7 +32,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Align sub-items to top */
                         align-items: start;
@@ -76,7 +77,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/media-object/index.tsx
+++ b/pages/media-object/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import Square from '../../placeholders/Square'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import Square from '../../placeholders/Square';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -77,7 +77,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/mega-menu/index.tsx
+++ b/pages/mega-menu/index.tsx
@@ -1,14 +1,15 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
-import Triangle from '../../placeholders/Triangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import Triangle from '../../placeholders/Triangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -40,7 +41,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Used to position the mega menu */
                         position: relative;
@@ -141,7 +142,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Dropdown, Pattern.Menu, Pattern.NestedDropdowns]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/mega-menu/index.tsx
+++ b/pages/mega-menu/index.tsx
@@ -1,15 +1,15 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import Triangle from '../../placeholders/Triangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import Triangle from '../../placeholders/Triangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -142,7 +142,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Dropdown, Pattern.Menu, Pattern.NestedDropdowns]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/menu/index.tsx
+++ b/pages/menu/index.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -221,7 +221,7 @@ const Details: React.FC<{}> = () => {
                 ]}
             />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/menu/index.tsx
+++ b/pages/menu/index.tsx
@@ -1,13 +1,14 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -54,7 +55,7 @@ const Details: React.FC<{}> = () => {
     <div class="menu__divider"></div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .menu {
                         display: flex;
                         flex-direction: column;
@@ -220,7 +221,7 @@ const Details: React.FC<{}> = () => {
                 ]}
             />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/modal/index.tsx
+++ b/pages/modal/index.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react'
-import Head from 'next/head'
-import Link from 'next/link'
+import * as React from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -127,7 +127,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/modal/index.tsx
+++ b/pages/modal/index.tsx
@@ -1,13 +1,14 @@
-import * as React from 'react';
-import Head from 'next/head';
-import Link from 'next/link';
+import * as React from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -45,7 +46,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .modal {
                         /* Border */
                         border: 1px solid rgba(0, 0, 0, 0.3);
@@ -126,7 +127,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/nested-dropdowns/index.tsx
+++ b/pages/nested-dropdowns/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -50,7 +51,7 @@ const Details: React.FC<{}> = () => {
     <li>About</li>
 </ul>
 `}
-                css={`
+                css={removeIndent`
                     .dropdown {
                         /* Border */
                         border: 1px solid rgba(0, 0, 0, 0.3);
@@ -143,7 +144,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Dropdown, Pattern.Menu]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/nested-dropdowns/index.tsx
+++ b/pages/nested-dropdowns/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -144,7 +144,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Dropdown, Pattern.Menu]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/notification/index.tsx
+++ b/pages/notification/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import Link from 'next/link'
+import * as React from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -83,7 +83,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/notification/index.tsx
+++ b/pages/notification/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import Link from 'next/link';
+import * as React from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -34,7 +35,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .notification {
                         display: flex;
                         justify-content: space-between;
@@ -82,7 +83,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/overlay-play-button/index.tsx
+++ b/pages/overlay-play-button/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Triangle from '../../placeholders/Triangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Triangle from '../../placeholders/Triangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -30,7 +31,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Used to position the overlay */
                         position: relative;
@@ -106,7 +107,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.VideoBackground]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/overlay-play-button/index.tsx
+++ b/pages/overlay-play-button/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Triangle from '../../placeholders/Triangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Triangle from '../../placeholders/Triangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -107,7 +107,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.VideoBackground]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/pagination/index.tsx
+++ b/pages/pagination/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -141,7 +141,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/pagination/index.tsx
+++ b/pages/pagination/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -28,7 +29,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .pagination {
                         display: flex;
 
@@ -140,7 +141,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/popover-arrow/index.tsx
+++ b/pages/popover-arrow/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -396,7 +396,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.ArrowButtons, Pattern.Tooltip]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/popover-arrow/index.tsx
+++ b/pages/popover-arrow/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -59,7 +60,7 @@ const Details: React.FC<{}> = () => {
     <div class="container__arrow container__arrow--lb"></div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Border */
                         border: 1px solid rgba(0, 0, 0, 0.3);
@@ -395,7 +396,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.ArrowButtons, Pattern.Tooltip]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/presence-indicator/index.tsx
+++ b/pages/presence-indicator/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -89,7 +89,7 @@ const Details: React.FC<{}> = () => {
                 patterns={[Pattern.Avatar, Pattern.AvatarList, Pattern.DockedAtCorner, Pattern.InitialAvatar]}
             />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/presence-indicator/index.tsx
+++ b/pages/presence-indicator/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -89,7 +89,7 @@ const Details: React.FC<{}> = () => {
                 patterns={[Pattern.Avatar, Pattern.AvatarList, Pattern.DockedAtCorner, Pattern.InitialAvatar]}
             />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/previous-next-buttons/index.tsx
+++ b/pages/previous-next-buttons/index.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Pattern } from '../../constants/Pattern'
+import * as React from 'react';
+import Head from 'next/head';
+import { Pattern } from '../../constants/Pattern';
 
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -86,7 +86,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/previous-next-buttons/index.tsx
+++ b/pages/previous-next-buttons/index.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Pattern } from '../../constants/Pattern';
+import * as React from 'react'
+import Head from 'next/head'
+import { Pattern } from '../../constants/Pattern'
 
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -25,7 +26,7 @@ const Details: React.FC<{}> = () => {
     <a>..</a>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         align-items: center;
                         display: flex;
@@ -85,7 +86,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/price-tag/index.tsx
+++ b/pages/price-tag/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -99,7 +99,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.TriangleButtons]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/price-tag/index.tsx
+++ b/pages/price-tag/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -22,7 +23,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     :root {
                         --price-tag-background: rgba(0, 0, 0, 0.3);
                         --price-tag-height: 2rem;
@@ -98,7 +99,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.TriangleButtons]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/pricing-table/index.tsx
+++ b/pages/pricing-table/index.tsx
@@ -1,15 +1,16 @@
-import * as React from 'react';
-import Head from 'next/head';
-import Link from 'next/link';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -52,7 +53,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Content is centered horizontally */
                         align-items: center;
@@ -180,7 +181,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.FeatureComparison]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/pricing-table/index.tsx
+++ b/pages/pricing-table/index.tsx
@@ -1,16 +1,16 @@
-import * as React from 'react'
-import Head from 'next/head'
-import Link from 'next/link'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -181,7 +181,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.FeatureComparison]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/progress-bar/index.tsx
+++ b/pages/progress-bar/index.tsx
@@ -1,17 +1,17 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Pattern } from '../../constants/Pattern'
+import * as React from 'react';
+import Head from 'next/head';
+import { Pattern } from '../../constants/Pattern';
 
-import useInterval from '../../hooks/useInterval'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import useInterval from '../../hooks/useInterval';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
-    const [progress, setProgress] = React.useState(0)
+    const [progress, setProgress] = React.useState(0);
     useInterval(() => {
-        setProgress((v) => (v === 100 ? 0 : v + 1))
-    }, 1 * 100)
+        setProgress((v) => (v === 100 ? 0 : v + 1));
+    }, 1 * 100);
 
     return (
         <PatternLayout pattern={Pattern.ProgressBar}>
@@ -95,7 +95,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/progress-bar/index.tsx
+++ b/pages/progress-bar/index.tsx
@@ -1,16 +1,17 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Pattern } from '../../constants/Pattern';
+import * as React from 'react'
+import Head from 'next/head'
+import { Pattern } from '../../constants/Pattern'
 
-import useInterval from '../../hooks/useInterval';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import useInterval from '../../hooks/useInterval'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
-    const [progress, setProgress] = React.useState(0);
+    const [progress, setProgress] = React.useState(0)
     useInterval(() => {
-        setProgress((v) => (v === 100 ? 0 : v + 1));
-    }, 1 * 100);
+        setProgress((v) => (v === 100 ? 0 : v + 1))
+    }, 1 * 100)
 
     return (
         <PatternLayout pattern={Pattern.ProgressBar}>
@@ -32,7 +33,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Colors */
                         background-color: rgba(0, 0, 0, 0.1);
@@ -94,7 +95,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/property-list/index.tsx
+++ b/pages/property-list/index.tsx
@@ -1,13 +1,14 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Heading, Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Heading, Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     const Item: React.FC<{}> = ({ children }) => {
@@ -24,8 +25,8 @@ const Details: React.FC<{}> = () => {
             >
                 {children}
             </dl>
-        );
-    };
+        )
+    }
 
     return (
         <PatternLayout pattern={Pattern.PropertyList}>
@@ -46,7 +47,7 @@ const Details: React.FC<{}> = () => {
     <dd>...</dd>
 </dl>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Content is center horizontally */
                         align-items: center;
@@ -139,7 +140,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.DotLeader, Pattern.Menu, Pattern.SplitNavigation]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/property-list/index.tsx
+++ b/pages/property-list/index.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Heading, Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Heading, Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     const Item: React.FC<{}> = ({ children }) => {
@@ -25,8 +25,8 @@ const Details: React.FC<{}> = () => {
             >
                 {children}
             </dl>
-        )
-    }
+        );
+    };
 
     return (
         <PatternLayout pattern={Pattern.PropertyList}>
@@ -140,7 +140,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.DotLeader, Pattern.Menu, Pattern.SplitNavigation]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/questions-and-answers/index.tsx
+++ b/pages/questions-and-answers/index.tsx
@@ -1,26 +1,27 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
-import Triangle from '../../placeholders/Triangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import Triangle from '../../placeholders/Triangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 interface ItemProps {
-    index: number;
-    title: React.ReactNode;
+    index: number
+    title: React.ReactNode
 }
 
 const Details: React.FC<{}> = () => {
-    const [activeItem, setActiveItem] = React.useState(-1);
+    const [activeItem, setActiveItem] = React.useState(-1)
 
     const Item: React.FC<ItemProps> = ({ index, title, children }) => {
-        const isOpened = index === activeItem;
-        const click = () => setActiveItem(isOpened ? -1 : index);
+        const isOpened = index === activeItem
+        const click = () => setActiveItem(isOpened ? -1 : index)
         return (
             <>
                 <div
@@ -45,8 +46,8 @@ const Details: React.FC<{}> = () => {
                     {children}
                 </div>
             </>
-        );
-    };
+        )
+    }
 
     return (
         <PatternLayout pattern={Pattern.QuestionsAndAnswers}>
@@ -72,7 +73,7 @@ const Details: React.FC<{}> = () => {
     <!-- Answer -->
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         border-bottom: 1px solid rgba(0, 0, 0, 0.3);
                     }
@@ -155,7 +156,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Accordion]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/questions-and-answers/index.tsx
+++ b/pages/questions-and-answers/index.tsx
@@ -1,27 +1,27 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import Triangle from '../../placeholders/Triangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import Triangle from '../../placeholders/Triangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 interface ItemProps {
-    index: number
-    title: React.ReactNode
+    index: number;
+    title: React.ReactNode;
 }
 
 const Details: React.FC<{}> = () => {
-    const [activeItem, setActiveItem] = React.useState(-1)
+    const [activeItem, setActiveItem] = React.useState(-1);
 
     const Item: React.FC<ItemProps> = ({ index, title, children }) => {
-        const isOpened = index === activeItem
-        const click = () => setActiveItem(isOpened ? -1 : index)
+        const isOpened = index === activeItem;
+        const click = () => setActiveItem(isOpened ? -1 : index);
         return (
             <>
                 <div
@@ -46,8 +46,8 @@ const Details: React.FC<{}> = () => {
                     {children}
                 </div>
             </>
-        )
-    }
+        );
+    };
 
     return (
         <PatternLayout pattern={Pattern.QuestionsAndAnswers}>
@@ -156,7 +156,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Accordion]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/radial-progress-bar/index.tsx
+++ b/pages/radial-progress-bar/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 interface RadialProgressProps {
-    percentages: number
+    percentages: number;
 }
 
 const RadialProgress: React.FC<RadialProgressProps> = ({ percentages }) => {
@@ -62,8 +62,8 @@ const RadialProgress: React.FC<RadialProgressProps> = ({ percentages }) => {
                 />
             </div>
         </div>
-    )
-}
+    );
+};
 
 const Details: React.FC<{}> = () => {
     return (
@@ -177,7 +177,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/radial-progress-bar/index.tsx
+++ b/pages/radial-progress-bar/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 interface RadialProgressProps {
-    percentages: number;
+    percentages: number
 }
 
 const RadialProgress: React.FC<RadialProgressProps> = ({ percentages }) => {
@@ -61,8 +62,8 @@ const RadialProgress: React.FC<RadialProgressProps> = ({ percentages }) => {
                 />
             </div>
         </div>
-    );
-};
+    )
+}
 
 const Details: React.FC<{}> = () => {
     return (
@@ -91,7 +92,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         position: relative;
                     }
@@ -176,7 +177,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/radio-button-group/index.tsx
+++ b/pages/radio-button-group/index.tsx
@@ -1,23 +1,23 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 interface RadioProps {
-    value: string
+    value: string;
 }
 
 const Details: React.FC<{}> = () => {
-    const [selectedValue, setSelectedValue] = React.useState('1')
+    const [selectedValue, setSelectedValue] = React.useState('1');
 
     const Radio: React.FC<RadioProps> = ({ value, children }) => {
-        const click = () => setSelectedValue(value)
+        const click = () => setSelectedValue(value);
 
         return (
             <label
@@ -40,8 +40,8 @@ const Details: React.FC<{}> = () => {
                 />
                 {children}
             </label>
-        )
-    }
+        );
+    };
 
     return (
         <PatternLayout pattern={Pattern.RadioButtonGroup}>
@@ -147,7 +147,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CustomCheckboxButton, Pattern.CustomRadioButton]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/radio-button-group/index.tsx
+++ b/pages/radio-button-group/index.tsx
@@ -1,22 +1,23 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 interface RadioProps {
-    value: string;
+    value: string
 }
 
 const Details: React.FC<{}> = () => {
-    const [selectedValue, setSelectedValue] = React.useState('1');
+    const [selectedValue, setSelectedValue] = React.useState('1')
 
     const Radio: React.FC<RadioProps> = ({ value, children }) => {
-        const click = () => setSelectedValue(value);
+        const click = () => setSelectedValue(value)
 
         return (
             <label
@@ -39,8 +40,8 @@ const Details: React.FC<{}> = () => {
                 />
                 {children}
             </label>
-        );
-    };
+        )
+    }
 
     return (
         <PatternLayout pattern={Pattern.RadioButtonGroup}>
@@ -66,7 +67,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         display: flex;
 
@@ -146,7 +147,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CustomCheckboxButton, Pattern.CustomRadioButton]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/radio-switch/index.tsx
+++ b/pages/radio-switch/index.tsx
@@ -1,15 +1,16 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Heading, Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Heading, Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
-    const [isFirstChecked, setFirstChecked] = React.useState(false);
-    const toggle = () => setFirstChecked((c) => !c);
+    const [isFirstChecked, setFirstChecked] = React.useState(false)
+    const toggle = () => setFirstChecked((c) => !c)
 
     return (
         <PatternLayout pattern={Pattern.RadioSwitch}>
@@ -35,7 +36,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         background-color: rgba(0, 0, 0, 0.1);
                         border-radius: 9999px;
@@ -177,7 +178,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Switch]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/radio-switch/index.tsx
+++ b/pages/radio-switch/index.tsx
@@ -1,16 +1,16 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Heading, Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Heading, Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
-    const [isFirstChecked, setFirstChecked] = React.useState(false)
-    const toggle = () => setFirstChecked((c) => !c)
+    const [isFirstChecked, setFirstChecked] = React.useState(false);
+    const toggle = () => setFirstChecked((c) => !c);
 
     return (
         <PatternLayout pattern={Pattern.RadioSwitch}>
@@ -178,7 +178,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Switch]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/rating/index.tsx
+++ b/pages/rating/index.tsx
@@ -1,17 +1,18 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 interface StarProps {
-    isActive: boolean;
+    isActive: boolean
 }
 
 const Star: React.FC<StarProps> = ({ isActive }) => {
-    return <button className="p-rating-star">{isActive ? '★' : '☆'}</button>;
-};
+    return <button className="p-rating-star">{isActive ? '★' : '☆'}</button>
+}
 
 const Details: React.FC<{}> = () => {
     return (
@@ -32,7 +33,7 @@ const Details: React.FC<{}> = () => {
     <button class="rating__star">★</button>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .rating {
                         /* Center the content */
                         align-items: center;
@@ -91,7 +92,7 @@ Note that we use \`flex-direction: row-reverse\` on the container
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/rating/index.tsx
+++ b/pages/rating/index.tsx
@@ -1,18 +1,18 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 interface StarProps {
-    isActive: boolean
+    isActive: boolean;
 }
 
 const Star: React.FC<StarProps> = ({ isActive }) => {
-    return <button className="p-rating-star">{isActive ? '★' : '☆'}</button>
-}
+    return <button className="p-rating-star">{isActive ? '★' : '☆'}</button>;
+};
 
 const Details: React.FC<{}> = () => {
     return (
@@ -92,7 +92,7 @@ Note that we use \`flex-direction: row-reverse\` on the container
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/resizable-element/index.tsx
+++ b/pages/resizable-element/index.tsx
@@ -1,9 +1,10 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -49,7 +50,7 @@ const Details: React.FC<{}> = () => {
     <div class="container__resizer container__resizer--lc"></div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Border */
                         border: 1px dashed rgba(0, 0, 0, 0.3);
@@ -267,7 +268,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/resizable-element/index.tsx
+++ b/pages/resizable-element/index.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -268,7 +268,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/ribbon/index.tsx
+++ b/pages/ribbon/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -36,7 +37,7 @@ const Details: React.FC<{}> = () => {
     <div class="container__side container__side--right"></div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Center the content */
                         align-items: center;
@@ -166,7 +167,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CornerRibbon]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/ribbon/index.tsx
+++ b/pages/ribbon/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -167,7 +167,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CornerRibbon]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/same-height-columns/index.tsx
+++ b/pages/same-height-columns/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -37,7 +38,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         display: flex;
                     }
@@ -133,7 +134,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/same-height-columns/index.tsx
+++ b/pages/same-height-columns/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -134,7 +134,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/search-box/index.tsx
+++ b/pages/search-box/index.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -25,7 +26,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         display: flex;
 
@@ -101,7 +102,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/search-box/index.tsx
+++ b/pages/search-box/index.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -102,7 +102,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/separator/index.tsx
+++ b/pages/separator/index.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -99,7 +99,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/separator/index.tsx
+++ b/pages/separator/index.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -27,7 +28,7 @@ const Details: React.FC<{}> = () => {
     <div class="container__separator"></div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Content is centered horizontally */
                         align-items: center;
@@ -98,7 +99,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/sidebar/index.tsx
+++ b/pages/sidebar/index.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -93,7 +93,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/sidebar/index.tsx
+++ b/pages/sidebar/index.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -30,7 +31,7 @@ const Details: React.FC<{}> = () => {
     </main>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         display: flex;
                     }
@@ -92,7 +93,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/simple-grid/index.tsx
+++ b/pages/simple-grid/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -30,7 +31,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .row {
                         display: flex;
 
@@ -139,7 +140,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CardLayout, Pattern.MasonryGrid]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/simple-grid/index.tsx
+++ b/pages/simple-grid/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -140,7 +140,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.CardLayout, Pattern.MasonryGrid]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/slider/index.tsx
+++ b/pages/slider/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -30,7 +31,7 @@ const Details: React.FC<{}> = () => {
     <div class="container__right"></div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Content is centered horizontally */
                         align-items: center;
@@ -98,7 +99,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/slider/index.tsx
+++ b/pages/slider/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -99,7 +99,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/spin-button/index.tsx
+++ b/pages/spin-button/index.tsx
@@ -1,18 +1,19 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Triangle from '../../placeholders/Triangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Triangle from '../../placeholders/Triangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
-    const [value, setValue] = React.useState(0);
-    const decrease = () => setValue(value - 1);
-    const increase = () => setValue(value + 1);
-    const change = (e: React.ChangeEvent<HTMLInputElement>) => setValue(parseInt(e.target.value, 10));
+    const [value, setValue] = React.useState(0)
+    const decrease = () => setValue(value - 1)
+    const increase = () => setValue(value + 1)
+    const change = (e: React.ChangeEvent<HTMLInputElement>) => setValue(parseInt(e.target.value, 10))
 
     return (
         <PatternLayout pattern={Pattern.SpinButton}>
@@ -42,7 +43,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         border: 1px solid rgba(0, 0, 0, 0.3);
                         border-radius: 2px;
@@ -133,7 +134,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.StepperInput, Pattern.Voting]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/spin-button/index.tsx
+++ b/pages/spin-button/index.tsx
@@ -1,19 +1,19 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Triangle from '../../placeholders/Triangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Triangle from '../../placeholders/Triangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
-    const [value, setValue] = React.useState(0)
-    const decrease = () => setValue(value - 1)
-    const increase = () => setValue(value + 1)
-    const change = (e: React.ChangeEvent<HTMLInputElement>) => setValue(parseInt(e.target.value, 10))
+    const [value, setValue] = React.useState(0);
+    const decrease = () => setValue(value - 1);
+    const increase = () => setValue(value + 1);
+    const change = (e: React.ChangeEvent<HTMLInputElement>) => setValue(parseInt(e.target.value, 10));
 
     return (
         <PatternLayout pattern={Pattern.SpinButton}>
@@ -134,7 +134,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.StepperInput, Pattern.Voting]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/split-navigation/index.tsx
+++ b/pages/split-navigation/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -89,7 +89,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.DotLeader, Pattern.Menu, Pattern.PropertyList]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/split-navigation/index.tsx
+++ b/pages/split-navigation/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -31,7 +32,7 @@ const Details: React.FC<{}> = () => {
     </li>
 </ul>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Content is centered horizontally */
                         align-items: center;
@@ -88,7 +89,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.DotLeader, Pattern.Menu, Pattern.PropertyList]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/split-screen/index.tsx
+++ b/pages/split-screen/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -81,7 +81,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/split-screen/index.tsx
+++ b/pages/split-screen/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -31,7 +32,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         display: flex;
                     }
@@ -80,7 +81,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/stacked-cards/index.tsx
+++ b/pages/stacked-cards/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -26,7 +27,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Used to position the stacked cards */
                         position: relative;
@@ -93,7 +94,7 @@ const Details: React.FC<{}> = () => {
                                             zIndex: -1,
                                         }}
                                     />
-                                );
+                                )
                             })}
                     </div>
                 </div>
@@ -102,7 +103,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Card, Pattern.LayeredCard, Pattern.ThreeDimensionsCard]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/stacked-cards/index.tsx
+++ b/pages/stacked-cards/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -94,7 +94,7 @@ const Details: React.FC<{}> = () => {
                                             zIndex: -1,
                                         }}
                                     />
-                                )
+                                );
                             })}
                     </div>
                 </div>
@@ -103,7 +103,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Card, Pattern.LayeredCard, Pattern.ThreeDimensionsCard]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/stamp-border/index.tsx
+++ b/pages/stamp-border/index.tsx
@@ -1,9 +1,10 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -24,7 +25,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Background */
                         background-color: #ccc;
@@ -75,7 +76,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/stamp-border/index.tsx
+++ b/pages/stamp-border/index.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -76,7 +76,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/statistic/index.tsx
+++ b/pages/statistic/index.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { random } from '../../utils/random'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { random } from '../../utils/random';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -77,7 +77,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/statistic/index.tsx
+++ b/pages/statistic/index.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { random } from '../../utils/random';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern'
+import { random } from '../../utils/random'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -29,7 +30,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Center the content */
                         align-items: center;
@@ -76,7 +77,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/status-light/index.tsx
+++ b/pages/status-light/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Heading, Spacer } from '@1milligram/design'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Heading, Spacer } from '@1milligram/design';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -166,7 +166,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </section>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/status-light/index.tsx
+++ b/pages/status-light/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Heading, Spacer } from '@1milligram/design';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { Heading, Spacer } from '@1milligram/design'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -28,7 +29,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Center the content */
                         align-items: center;
@@ -165,7 +166,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </section>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/stepper-input/index.tsx
+++ b/pages/stepper-input/index.tsx
@@ -1,21 +1,22 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
-    const [value, setValue] = React.useState(0);
-    const decrease = () => setValue(value - 1);
-    const increase = () => setValue(value + 1);
+    const [value, setValue] = React.useState(0)
+    const decrease = () => setValue(value - 1)
+    const increase = () => setValue(value + 1)
     const change = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const v = parseInt(e.target.value, 10);
-        const newValue = isNaN(v) ? 0 : v;
-        setValue(newValue);
-    };
+        const v = parseInt(e.target.value, 10)
+        const newValue = isNaN(v) ? 0 : v
+        setValue(newValue)
+    }
 
     return (
         <PatternLayout pattern={Pattern.StepperInput}>
@@ -40,7 +41,7 @@ const Details: React.FC<{}> = () => {
     <button class="stepper__button">+</button>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .stepper {
                         display: flex;
 
@@ -146,7 +147,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.SpinButton, Pattern.Voting]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/stepper-input/index.tsx
+++ b/pages/stepper-input/index.tsx
@@ -1,22 +1,22 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
-    const [value, setValue] = React.useState(0)
-    const decrease = () => setValue(value - 1)
-    const increase = () => setValue(value + 1)
+    const [value, setValue] = React.useState(0);
+    const decrease = () => setValue(value - 1);
+    const increase = () => setValue(value + 1);
     const change = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const v = parseInt(e.target.value, 10)
-        const newValue = isNaN(v) ? 0 : v
-        setValue(newValue)
-    }
+        const v = parseInt(e.target.value, 10);
+        const newValue = isNaN(v) ? 0 : v;
+        setValue(newValue);
+    };
 
     return (
         <PatternLayout pattern={Pattern.StepperInput}>
@@ -147,7 +147,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.SpinButton, Pattern.Voting]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/sticky-footer/index.tsx
+++ b/pages/sticky-footer/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -86,7 +86,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/sticky-footer/index.tsx
+++ b/pages/sticky-footer/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -33,7 +34,7 @@ const Details: React.FC<{}> = () => {
     </footer>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         display: flex;
                         flex-direction: column;
@@ -85,7 +86,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/sticky-header/index.tsx
+++ b/pages/sticky-header/index.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -75,7 +75,7 @@ const Details: React.FC<{}> = () => {
                 patterns={[Pattern.StickySections, Pattern.StickyTableColumn, Pattern.StickyTableHeaders]}
             />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/sticky-header/index.tsx
+++ b/pages/sticky-header/index.tsx
@@ -1,13 +1,14 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -32,7 +33,7 @@ const Details: React.FC<{}> = () => {
     </main>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .header {
                         /* Stick to the top */
                         position: sticky;
@@ -74,7 +75,7 @@ const Details: React.FC<{}> = () => {
                 patterns={[Pattern.StickySections, Pattern.StickyTableColumn, Pattern.StickyTableHeaders]}
             />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/sticky-sections/index.tsx
+++ b/pages/sticky-sections/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -30,7 +31,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         height: 100%;
                         overflow: scroll;
@@ -85,7 +86,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.StickyHeader, Pattern.StickyTableColumn, Pattern.StickyTableHeaders]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/sticky-sections/index.tsx
+++ b/pages/sticky-sections/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -86,7 +86,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.StickyHeader, Pattern.StickyTableColumn, Pattern.StickyTableHeaders]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/sticky-table-column/index.tsx
+++ b/pages/sticky-table-column/index.tsx
@@ -1,17 +1,18 @@
 // tslint:disable:prefer-object-spread
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
-    const numberOfColumns = 10;
+    const numberOfColumns = 10
     return (
         <PatternLayout pattern={Pattern.StickyTableColumn}>
             <Head>
@@ -39,7 +40,7 @@ const Details: React.FC<{}> = () => {
     </tbody>
 </table>
 `}
-                css={`
+                css={removeIndent`
                     .header {
                         /* Background color */
                         background-color: #ddd;
@@ -102,7 +103,7 @@ const Details: React.FC<{}> = () => {
                                                         {index === 0 ? <Rectangle /> : <Block numberOfBlocks={3} />}
                                                     </div>
                                                 </th>
-                                            );
+                                            )
                                         })}
                                 </tr>
                             </thead>
@@ -137,10 +138,10 @@ const Details: React.FC<{}> = () => {
                                                                     <Block numberOfBlocks={3} />
                                                                 )}
                                                             </td>
-                                                        );
+                                                        )
                                                     })}
                                             </tr>
-                                        );
+                                        )
                                     })}
                             </tbody>
                         </table>
@@ -150,7 +151,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.StickyHeader, Pattern.StickySections, Pattern.StickyTableHeaders]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/sticky-table-column/index.tsx
+++ b/pages/sticky-table-column/index.tsx
@@ -1,18 +1,18 @@
 // tslint:disable:prefer-object-spread
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
-    const numberOfColumns = 10
+    const numberOfColumns = 10;
     return (
         <PatternLayout pattern={Pattern.StickyTableColumn}>
             <Head>
@@ -103,7 +103,7 @@ const Details: React.FC<{}> = () => {
                                                         {index === 0 ? <Rectangle /> : <Block numberOfBlocks={3} />}
                                                     </div>
                                                 </th>
-                                            )
+                                            );
                                         })}
                                 </tr>
                             </thead>
@@ -138,10 +138,10 @@ const Details: React.FC<{}> = () => {
                                                                     <Block numberOfBlocks={3} />
                                                                 )}
                                                             </td>
-                                                        )
+                                                        );
                                                     })}
                                             </tr>
-                                        )
+                                        );
                                     })}
                             </tbody>
                         </table>
@@ -151,7 +151,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.StickyHeader, Pattern.StickySections, Pattern.StickyTableHeaders]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/sticky-table-headers/index.tsx
+++ b/pages/sticky-table-headers/index.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -94,7 +94,7 @@ const Details: React.FC<{}> = () => {
                                                 >
                                                     <Rectangle />
                                                 </th>
-                                            )
+                                            );
                                         })}
                                 </tr>
                             </thead>
@@ -111,10 +111,10 @@ const Details: React.FC<{}> = () => {
                                                             <td key={col} style={{ padding: '16px' }}>
                                                                 <Block numberOfBlocks={3} />
                                                             </td>
-                                                        )
+                                                        );
                                                     })}
                                             </tr>
-                                        )
+                                        );
                                     })}
                             </tbody>
                         </table>
@@ -125,7 +125,7 @@ const Details: React.FC<{}> = () => {
 
             <RelatedPatterns patterns={[Pattern.StickyHeader, Pattern.StickySections, Pattern.StickyTableColumn]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/sticky-table-headers/index.tsx
+++ b/pages/sticky-table-headers/index.tsx
@@ -1,13 +1,14 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -37,7 +38,7 @@ const Details: React.FC<{}> = () => {
     </tbody>
 </table>
 `}
-                css={`
+                css={removeIndent`
                     .header {
                         /* Background color */
                         background-color: #ddd;
@@ -93,7 +94,7 @@ const Details: React.FC<{}> = () => {
                                                 >
                                                     <Rectangle />
                                                 </th>
-                                            );
+                                            )
                                         })}
                                 </tr>
                             </thead>
@@ -110,10 +111,10 @@ const Details: React.FC<{}> = () => {
                                                             <td key={col} style={{ padding: '16px' }}>
                                                                 <Block numberOfBlocks={3} />
                                                             </td>
-                                                        );
+                                                        )
                                                     })}
                                             </tr>
-                                        );
+                                        )
                                     })}
                             </tbody>
                         </table>
@@ -124,7 +125,7 @@ const Details: React.FC<{}> = () => {
 
             <RelatedPatterns patterns={[Pattern.StickyHeader, Pattern.StickySections, Pattern.StickyTableColumn]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/switch/index.tsx
+++ b/pages/switch/index.tsx
@@ -1,15 +1,16 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
-    const [checked, setChecked] = React.useState(false);
-    const toggle = () => setChecked((c) => !c);
+    const [checked, setChecked] = React.useState(false)
+    const toggle = () => setChecked((c) => !c)
 
     return (
         <PatternLayout pattern={Pattern.Switch}>
@@ -32,7 +33,7 @@ const Details: React.FC<{}> = () => {
     <div class="label__circle"></div>
 </label>
 `}
-                css={`
+                css={removeIndent`
                     .label {
                         display: flex;
 
@@ -116,7 +117,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.RadioSwitch]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/switch/index.tsx
+++ b/pages/switch/index.tsx
@@ -1,16 +1,16 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
-    const [checked, setChecked] = React.useState(false)
-    const toggle = () => setChecked((c) => !c)
+    const [checked, setChecked] = React.useState(false);
+    const toggle = () => setChecked((c) => !c);
 
     return (
         <PatternLayout pattern={Pattern.Switch}>
@@ -117,7 +117,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.RadioSwitch]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/tab/index.tsx
+++ b/pages/tab/index.tsx
@@ -1,22 +1,22 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 interface TabProps {
-    tabIndex: number
+    tabIndex: number;
 }
 
 const Details: React.FC<{}> = () => {
-    const [activeTab, setActiveTab] = React.useState(0)
+    const [activeTab, setActiveTab] = React.useState(0);
 
     const Tab: React.FC<TabProps> = ({ tabIndex, children }) => {
-        const isActive = tabIndex === activeTab
-        const click = () => setActiveTab(tabIndex)
+        const isActive = tabIndex === activeTab;
+        const click = () => setActiveTab(tabIndex);
         return (
             <div
                 style={{
@@ -31,8 +31,8 @@ const Details: React.FC<{}> = () => {
             >
                 {children}
             </div>
-        )
-    }
+        );
+    };
 
     return (
         <PatternLayout pattern={Pattern.Tab}>
@@ -117,7 +117,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/tab/index.tsx
+++ b/pages/tab/index.tsx
@@ -1,21 +1,22 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 interface TabProps {
-    tabIndex: number;
+    tabIndex: number
 }
 
 const Details: React.FC<{}> = () => {
-    const [activeTab, setActiveTab] = React.useState(0);
+    const [activeTab, setActiveTab] = React.useState(0)
 
     const Tab: React.FC<TabProps> = ({ tabIndex, children }) => {
-        const isActive = tabIndex === activeTab;
-        const click = () => setActiveTab(tabIndex);
+        const isActive = tabIndex === activeTab
+        const click = () => setActiveTab(tabIndex)
         return (
             <div
                 style={{
@@ -30,8 +31,8 @@ const Details: React.FC<{}> = () => {
             >
                 {children}
             </div>
-        );
-    };
+        )
+    }
 
     return (
         <PatternLayout pattern={Pattern.Tab}>
@@ -55,7 +56,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .tabs {
                         /* Center the content */
                         align-items: center;
@@ -116,7 +117,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/teardrop/index.tsx
+++ b/pages/teardrop/index.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -81,7 +81,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/teardrop/index.tsx
+++ b/pages/teardrop/index.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -27,7 +28,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Center the content */
                         align-items: center;
@@ -80,7 +81,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/three-dimensions-card/index.tsx
+++ b/pages/three-dimensions-card/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -22,7 +23,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     :root {
                         --three-dimensions-card-left-side-width: 1rem;
                     }
@@ -90,7 +91,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Card, Pattern.LayeredCard, Pattern.StackedCards]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/three-dimensions-card/index.tsx
+++ b/pages/three-dimensions-card/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -91,7 +91,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Card, Pattern.LayeredCard, Pattern.StackedCards]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/timeline/index.tsx
+++ b/pages/timeline/index.tsx
@@ -1,15 +1,15 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { Pattern } from '../../constants/Pattern'
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -188,7 +188,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.ZigzagTimeline]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/timeline/index.tsx
+++ b/pages/timeline/index.tsx
@@ -1,14 +1,15 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { Pattern } from '../../constants/Pattern';
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -51,7 +52,7 @@ const Details: React.FC<{}> = () => {
     </ul>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Used to position the left vertical line */
                         position: relative;
@@ -187,7 +188,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.ZigzagTimeline]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/toggle-password-visibility/index.tsx
+++ b/pages/toggle-password-visibility/index.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
-    const [visible, setVisible] = React.useState(false)
-    const toggle = () => setVisible((v) => !v)
+    const [visible, setVisible] = React.useState(false);
+    const toggle = () => setVisible((v) => !v);
 
     return (
         <PatternLayout pattern={Pattern.TogglePasswordVisibility}>
@@ -103,7 +103,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/toggle-password-visibility/index.tsx
+++ b/pages/toggle-password-visibility/index.tsx
@@ -1,13 +1,14 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
-    const [visible, setVisible] = React.useState(false);
-    const toggle = () => setVisible((v) => !v);
+    const [visible, setVisible] = React.useState(false)
+    const toggle = () => setVisible((v) => !v)
 
     return (
         <PatternLayout pattern={Pattern.TogglePasswordVisibility}>
@@ -29,7 +30,7 @@ const Details: React.FC<{}> = () => {
     </button>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         display: flex;
 
@@ -102,7 +103,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/tooltip/index.tsx
+++ b/pages/tooltip/index.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -131,7 +131,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.PopoverArrow]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/tooltip/index.tsx
+++ b/pages/tooltip/index.tsx
@@ -1,13 +1,14 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -36,7 +37,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Used to position the arrow */
                         position: relative;
@@ -130,7 +131,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.PopoverArrow]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/tree-diagram/index.tsx
+++ b/pages/tree-diagram/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Square from '../../placeholders/Square'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Square from '../../placeholders/Square';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -192,7 +192,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.FolderStructure]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/tree-diagram/index.tsx
+++ b/pages/tree-diagram/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Square from '../../placeholders/Square';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Square from '../../placeholders/Square'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -48,7 +49,7 @@ const Details: React.FC<{}> = () => {
     </ul>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .tree-diagram ul {
                         display: flex;
                         position: relative;
@@ -191,7 +192,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.FolderStructure]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/triangle-buttons/index.tsx
+++ b/pages/triangle-buttons/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -237,7 +237,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.ArrowButtons, Pattern.PriceTag, Pattern.Voting]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/triangle-buttons/index.tsx
+++ b/pages/triangle-buttons/index.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -54,7 +55,7 @@ const Details: React.FC<{}> = () => {
     ...
 </button>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Center the content */
                         align-items: center;
@@ -236,7 +237,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.ArrowButtons, Pattern.PriceTag, Pattern.Voting]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/upload-button/index.tsx
+++ b/pages/upload-button/index.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -29,7 +30,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Used to position the input */
                         position: relative;
@@ -119,7 +120,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/upload-button/index.tsx
+++ b/pages/upload-button/index.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -120,7 +120,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/validation-icon/index.tsx
+++ b/pages/validation-icon/index.tsx
@@ -1,9 +1,10 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -27,7 +28,7 @@ const Details: React.FC<{}> = () => {
     </span>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Used to position the validation icon */
                         position: relative;
@@ -152,7 +153,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/validation-icon/index.tsx
+++ b/pages/validation-icon/index.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -153,7 +153,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/video-background/index.tsx
+++ b/pages/video-background/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -150,7 +150,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.FullBackground, Pattern.OverlayPlayButton]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/video-background/index.tsx
+++ b/pages/video-background/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -36,7 +37,7 @@ const Details: React.FC<{}> = () => {
     </div>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Used to position the video and content */
                         position: relative;
@@ -149,7 +150,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.FullBackground, Pattern.OverlayPlayButton]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/voting/index.tsx
+++ b/pages/voting/index.tsx
@@ -1,16 +1,17 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
-    const [value, setValue] = React.useState(900);
-    const decrease = () => setValue(value - 1);
-    const increase = () => setValue(value + 1);
+    const [value, setValue] = React.useState(900)
+    const decrease = () => setValue(value - 1)
+    const increase = () => setValue(value + 1)
 
     return (
         <PatternLayout pattern={Pattern.Voting}>
@@ -39,7 +40,7 @@ const Details: React.FC<{}> = () => {
     </button>
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .voting {
                         border: 1px solid rgba(0, 0, 0, 0.3);
                         border-radius: 0.25rem;
@@ -176,7 +177,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.SpinButton, Pattern.StepperInput, Pattern.TriangleButtons]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/voting/index.tsx
+++ b/pages/voting/index.tsx
@@ -1,17 +1,17 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
-    const [value, setValue] = React.useState(900)
-    const decrease = () => setValue(value - 1)
-    const increase = () => setValue(value + 1)
+    const [value, setValue] = React.useState(900);
+    const decrease = () => setValue(value - 1);
+    const increase = () => setValue(value + 1);
 
     return (
         <PatternLayout pattern={Pattern.Voting}>
@@ -177,7 +177,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.SpinButton, Pattern.StepperInput, Pattern.TriangleButtons]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/watermark/index.tsx
+++ b/pages/watermark/index.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -129,7 +129,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/watermark/index.tsx
+++ b/pages/watermark/index.tsx
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -30,7 +31,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .container {
                         /* Used to position the watermark */
                         position: relative;
@@ -128,7 +129,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/wizard/index.tsx
+++ b/pages/wizard/index.tsx
@@ -1,12 +1,13 @@
-import * as React from 'react';
-import Head from 'next/head';
+import * as React from 'react'
+import Head from 'next/head'
 
-import { Pattern } from '../../constants/Pattern';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Circle from '../../placeholders/Circle';
-import Line from '../../placeholders/Line';
+import { Pattern } from '../../constants/Pattern'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Circle from '../../placeholders/Circle'
+import Line from '../../placeholders/Line'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -43,7 +44,7 @@ const Details: React.FC<{}> = () => {
     ...
 </div>
 `}
-                css={`
+                css={removeIndent`
                     .wizard {
                         display: flex;
                     }
@@ -190,7 +191,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pages/wizard/index.tsx
+++ b/pages/wizard/index.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
-import Head from 'next/head'
+import * as React from 'react';
+import Head from 'next/head';
 
-import { Pattern } from '../../constants/Pattern'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Circle from '../../placeholders/Circle'
-import Line from '../../placeholders/Line'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Circle from '../../placeholders/Circle';
+import Line from '../../placeholders/Line';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -191,7 +191,7 @@ const Details: React.FC<{}> = () => {
                 </div>
             </BrowserFrame>
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/zigzag-timeline/index.tsx
+++ b/pages/zigzag-timeline/index.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react'
-import Head from 'next/head'
-import { Spacer } from '@1milligram/design'
+import * as React from 'react';
+import Head from 'next/head';
+import { Spacer } from '@1milligram/design';
 
-import { Pattern } from '../../constants/Pattern'
-import { RelatedPatterns } from '../../components/RelatedPatterns'
-import { PatternLayout } from '../../layouts/PatternLayout'
-import Block from '../../placeholders/Block'
-import BrowserFrame from '../../placeholders/BrowserFrame'
-import Rectangle from '../../placeholders/Rectangle'
-import { removeIndent } from '../../utils/removeIndent'
+import { Pattern } from '../../constants/Pattern';
+import { RelatedPatterns } from '../../components/RelatedPatterns';
+import { PatternLayout } from '../../layouts/PatternLayout';
+import Block from '../../placeholders/Block';
+import BrowserFrame from '../../placeholders/BrowserFrame';
+import Rectangle from '../../placeholders/Rectangle';
+import { removeIndent } from '../../utils/removeIndent';
 
 const Details: React.FC<{}> = () => {
     return (
@@ -131,7 +131,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Timeline]} />
         </PatternLayout>
-    )
-}
+    );
+};
 
-export default Details
+export default Details;

--- a/pages/zigzag-timeline/index.tsx
+++ b/pages/zigzag-timeline/index.tsx
@@ -1,13 +1,14 @@
-import * as React from 'react';
-import Head from 'next/head';
-import { Spacer } from '@1milligram/design';
+import * as React from 'react'
+import Head from 'next/head'
+import { Spacer } from '@1milligram/design'
 
-import { Pattern } from '../../constants/Pattern';
-import { RelatedPatterns } from '../../components/RelatedPatterns';
-import { PatternLayout } from '../../layouts/PatternLayout';
-import Block from '../../placeholders/Block';
-import BrowserFrame from '../../placeholders/BrowserFrame';
-import Rectangle from '../../placeholders/Rectangle';
+import { Pattern } from '../../constants/Pattern'
+import { RelatedPatterns } from '../../components/RelatedPatterns'
+import { PatternLayout } from '../../layouts/PatternLayout'
+import Block from '../../placeholders/Block'
+import BrowserFrame from '../../placeholders/BrowserFrame'
+import Rectangle from '../../placeholders/Rectangle'
+import { removeIndent } from '../../utils/removeIndent'
 
 const Details: React.FC<{}> = () => {
     return (
@@ -31,7 +32,7 @@ const Details: React.FC<{}> = () => {
 <!-- Repeat other items -->
 ...
 `}
-                css={`
+                css={removeIndent`
                     .zigzag-timeline__item {
                         /* Used to position the milestone */
                         position: relative;
@@ -130,7 +131,7 @@ const Details: React.FC<{}> = () => {
             <Spacer size="extraLarge" />
             <RelatedPatterns patterns={[Pattern.Timeline]} />
         </PatternLayout>
-    );
-};
+    )
+}
 
-export default Details;
+export default Details

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,2563 @@
+lockfileVersion: 5.4
+
+specifiers:
+  '@1milligram/design': ^0.4.1
+  '@mdx-js/loader': ^2.0.0
+  '@mdx-js/react': ^2.0.0
+  '@next/mdx': ^12.1.0
+  '@types/react': ^17.0.39
+  '@types/react-dom': ^17.0.11
+  next: ^12.1.0
+  prettier: ^2.5.1
+  prism-react-renderer: ^1.3.1
+  puppeteer: ^13.4.0
+  react: ^17.0.2
+  react-dom: ^17.0.2
+  sass: ^1.49.9
+  serve: ^13.0.2
+  ts-loader: ^9.2.6
+  ts-node: ^10.5.0
+  tslint: ^6.1.3
+  tslint-react: ^5.0.0
+  typescript: ^4.5.5
+
+dependencies:
+  '@1milligram/design': 0.4.1_nsrodebypp3mcf7ihyfjqmpudu
+  '@mdx-js/loader': 2.1.2
+  '@mdx-js/react': 2.1.2_react@17.0.2
+  '@next/mdx': 12.2.0_todqhrvd7cvbb36hzi2r6xttgq
+  next: 12.2.0_352uutu4og2bvewd2z7ffpt77y
+  prism-react-renderer: 1.3.5_react@17.0.2
+  react: 17.0.2
+  react-dom: 17.0.2_react@17.0.2
+
+devDependencies:
+  '@types/react': 17.0.47
+  '@types/react-dom': 17.0.17
+  prettier: 2.7.1
+  puppeteer: 13.7.0
+  sass: 1.53.0
+  serve: 13.0.4
+  ts-loader: 9.3.1_typescript@4.7.4
+  ts-node: 10.8.2_typescript@4.7.4
+  tslint: 6.1.3_typescript@4.7.4
+  tslint-react: 5.0.0_2d4q7cprazhk3fo4dnvjdmavtq
+  typescript: 4.7.4
+
+packages:
+
+  /@1milligram/design/0.4.1_nsrodebypp3mcf7ihyfjqmpudu:
+    resolution: {integrity: sha512-F1fXRibOdDJbGbjhNzu9obla7Yg2Th/iRbKI39qwllmkbhx5Q/cj5kyHZSax2fqenj69KR00HpnnBy31C3gwjw==}
+    peerDependencies:
+      next: ^12.0.0
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      next: 12.2.0_352uutu4og2bvewd2z7ffpt77y
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    dev: false
+
+  /@babel/code-frame/7.18.6:
+    resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.18.6
+    dev: true
+
+  /@babel/helper-validator-identifier/7.18.6:
+    resolution: {integrity: sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/highlight/7.18.6:
+    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.18.6
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+
+  /@cspotcode/source-map-support/0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    dev: true
+
+  /@jridgewell/resolve-uri/3.1.0:
+    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/sourcemap-codec/1.4.14:
+    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
+    dev: true
+
+  /@jridgewell/trace-mapping/0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
+  /@mdx-js/loader/2.1.2:
+    resolution: {integrity: sha512-P7CWhrqE5rZ3ewBngZ9t/zQPbSq42iuty78K3zJ8Bl518qnOX1d106c+n7I/zHODPAmw9JfYMQdbv9WrrHa0DA==}
+    peerDependencies:
+      webpack: '>=4'
+    dependencies:
+      '@mdx-js/mdx': 2.1.2
+      source-map: 0.7.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@mdx-js/mdx/2.1.2:
+    resolution: {integrity: sha512-ASN1GUH0gXsgJ2UD/Td7FzJo1SwFkkQ5V1i9at5o/ROra7brkyMcBsotsOWJWRzmXZaLw2uXWn4aN8B3PMNFMA==}
+    dependencies:
+      '@types/estree-jsx': 0.0.1
+      '@types/mdx': 2.0.2
+      astring: 1.8.3
+      estree-util-build-jsx: 2.1.0
+      estree-util-is-identifier-name: 2.0.1
+      estree-walker: 3.0.1
+      hast-util-to-estree: 2.0.2
+      markdown-extensions: 1.1.1
+      periscopic: 3.0.4
+      remark-mdx: 2.1.2
+      remark-parse: 10.0.1
+      remark-rehype: 10.1.0
+      unified: 10.1.2
+      unist-util-position-from-estree: 1.1.1
+      unist-util-stringify-position: 3.0.2
+      unist-util-visit: 4.1.0
+      vfile: 5.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@mdx-js/react/2.1.2_react@17.0.2:
+    resolution: {integrity: sha512-52e3DTJBrjsw3U51ZCdZ3N1IBaqnbzLIngCSXpKtiYiGr7PIqp3/P/+kym0MPTwBL/y9ZBmCieD8FyrXuEDrRw==}
+    peerDependencies:
+      react: '>=16'
+    dependencies:
+      '@types/mdx': 2.0.2
+      '@types/react': 17.0.47
+      react: 17.0.2
+    dev: false
+
+  /@next/env/12.2.0:
+    resolution: {integrity: sha512-/FCkDpL/8SodJEXvx/DYNlOD5ijTtkozf4PPulYPtkPOJaMPpBSOkzmsta4fnrnbdH6eZjbwbiXFdr6gSQCV4w==}
+    dev: false
+
+  /@next/mdx/12.2.0_todqhrvd7cvbb36hzi2r6xttgq:
+    resolution: {integrity: sha512-obWsgfD0/1+OOr4PMQlSal34uhIDxkFe9Db+LaFfRDbsmD8+gb0YevUOV5KBoleEHXfDku0WAPUUmPmDiAxu1w==}
+    peerDependencies:
+      '@mdx-js/loader': '>=0.15.0'
+      '@mdx-js/react': '*'
+    dependencies:
+      '@mdx-js/loader': 2.1.2
+      '@mdx-js/react': 2.1.2_react@17.0.2
+    dev: false
+
+  /@next/swc-android-arm-eabi/12.2.0:
+    resolution: {integrity: sha512-hbneH8DNRB2x0Nf5fPCYoL8a0osvdTCe4pvOc9Rv5CpDsoOlf8BWBs2OWpeP0U2BktGvIsuUhmISmdYYGyrvTw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-android-arm64/12.2.0:
+    resolution: {integrity: sha512-1eEk91JHjczcJomxJ8X0XaUeNcp5Lx1U2Ic7j15ouJ83oRX+3GIslOuabW2oPkSgXbHkThMClhirKpvG98kwZg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-darwin-arm64/12.2.0:
+    resolution: {integrity: sha512-x5U5gJd7ZvrEtTFnBld9O2bUlX8opu7mIQUqRzj7KeWzBwPhrIzTTsQXAiNqsaMuaRPvyHBVW/5d/6g6+89Y8g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-darwin-x64/12.2.0:
+    resolution: {integrity: sha512-iwMNFsrAPjfedjKDv9AXPAV16PWIomP3qw/FfPaxkDVRbUls7BNdofBLzkQmqxqWh93WrawLwaqyXpJuAaiwJA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-freebsd-x64/12.2.0:
+    resolution: {integrity: sha512-gRiAw8g3Akf6niTDLEm1Emfa7jXDjvaAj/crDO8hKASKA4Y1fS4kbi/tyWw5VtoFI4mUzRmCPmZ8eL0tBSG58A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-arm-gnueabihf/12.2.0:
+    resolution: {integrity: sha512-/TJZkxaIpeEwnXh6A40trgwd40C5+LJroLUOEQwMOJdavLl62PjCA6dGl1pgooWLCIb5YdBQ0EG4ylzvLwS2+Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-arm64-gnu/12.2.0:
+    resolution: {integrity: sha512-++WAB4ElXCSOKG9H8r4ENF8EaV+w0QkrpjehmryFkQXmt5juVXz+nKDVlCRMwJU7A1O0Mie82XyEoOrf6Np1pA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-arm64-musl/12.2.0:
+    resolution: {integrity: sha512-XrqkHi/VglEn5zs2CYK6ofJGQySrd+Lr4YdmfJ7IhsCnMKkQY1ma9Hv5THwhZVof3e+6oFHrQ9bWrw9K4WTjFA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-x64-gnu/12.2.0:
+    resolution: {integrity: sha512-MyhHbAKVjpn065WzRbqpLu2krj4kHLi6RITQdD1ee+uxq9r2yg5Qe02l24NxKW+1/lkmpusl4Y5Lks7rBiJn4w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-linux-x64-musl/12.2.0:
+    resolution: {integrity: sha512-Tz1tJZ5egE0S/UqCd5V6ZPJsdSzv/8aa7FkwFmIJ9neLS8/00za+OY5pq470iZQbPrkTwpKzmfTTIPRVD5iqDg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-win32-arm64-msvc/12.2.0:
+    resolution: {integrity: sha512-0iRO/CPMCdCYUzuH6wXLnsfJX1ykBX4emOOvH0qIgtiZM0nVYbF8lkEyY2ph4XcsurpinS+ziWuYCXVqrOSqiw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-win32-ia32-msvc/12.2.0:
+    resolution: {integrity: sha512-8A26RJVcJHwIKm8xo/qk2ePRquJ6WCI2keV2qOW/Qm+ZXrPXHMIWPYABae/nKN243YFBNyPiHytjX37VrcpUhg==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@next/swc-win32-x64-msvc/12.2.0:
+    resolution: {integrity: sha512-OI14ozFLThEV3ey6jE47zrzSTV/6eIMsvbwozo+XfdWqOPwQ7X00YkRx4GVMKMC0rM44oGS2gmwMKYpe4EblnA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@swc/helpers/0.4.2:
+    resolution: {integrity: sha512-556Az0VX7WR6UdoTn4htt/l3zPQ7bsQWK+HqdG4swV7beUCxo/BqmvbOpUkTIm/9ih86LIf1qsUnywNL3obGHw==}
+    dependencies:
+      tslib: 2.4.0
+    dev: false
+
+  /@tsconfig/node10/1.0.9:
+    resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
+    dev: true
+
+  /@tsconfig/node12/1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: true
+
+  /@tsconfig/node14/1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
+
+  /@tsconfig/node16/1.0.3:
+    resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
+    dev: true
+
+  /@types/acorn/4.0.6:
+    resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
+    dependencies:
+      '@types/estree': 0.0.52
+    dev: false
+
+  /@types/debug/4.1.7:
+    resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
+    dependencies:
+      '@types/ms': 0.7.31
+    dev: false
+
+  /@types/estree-jsx/0.0.1:
+    resolution: {integrity: sha512-gcLAYiMfQklDCPjQegGn0TBAn9it05ISEsEhlKQUddIk7o2XDokOcTN7HBO8tznM0D9dGezvHEfRZBfZf6me0A==}
+    dependencies:
+      '@types/estree': 0.0.52
+    dev: false
+
+  /@types/estree/0.0.51:
+    resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
+    dev: false
+
+  /@types/estree/0.0.52:
+    resolution: {integrity: sha512-BZWrtCU0bMVAIliIV+HJO1f1PR41M7NKjfxrFJwwhKI1KwhwOxYw1SXg9ao+CIMt774nFuGiG6eU+udtbEI9oQ==}
+    dev: false
+
+  /@types/hast/2.3.4:
+    resolution: {integrity: sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==}
+    dependencies:
+      '@types/unist': 2.0.6
+    dev: false
+
+  /@types/mdast/3.0.10:
+    resolution: {integrity: sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==}
+    dependencies:
+      '@types/unist': 2.0.6
+    dev: false
+
+  /@types/mdurl/1.0.2:
+    resolution: {integrity: sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==}
+    dev: false
+
+  /@types/mdx/2.0.2:
+    resolution: {integrity: sha512-mJGfgj4aWpiKb8C0nnJJchs1sHBHn0HugkVfqqyQi7Wn6mBRksLeQsPOFvih/Pu8L1vlDzfe/LidhVHBeUk3aQ==}
+    dev: false
+
+  /@types/ms/0.7.31:
+    resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
+    dev: false
+
+  /@types/node/18.0.3:
+    resolution: {integrity: sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ==}
+    dev: true
+    optional: true
+
+  /@types/prop-types/15.7.5:
+    resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
+
+  /@types/react-dom/17.0.17:
+    resolution: {integrity: sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==}
+    dependencies:
+      '@types/react': 17.0.47
+    dev: true
+
+  /@types/react/17.0.47:
+    resolution: {integrity: sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==}
+    dependencies:
+      '@types/prop-types': 15.7.5
+      '@types/scheduler': 0.16.2
+      csstype: 3.1.0
+
+  /@types/scheduler/0.16.2:
+    resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
+
+  /@types/unist/2.0.6:
+    resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
+    dev: false
+
+  /@types/yauzl/2.10.0:
+    resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
+    requiresBuild: true
+    dependencies:
+      '@types/node': 18.0.3
+    dev: true
+    optional: true
+
+  /@zeit/schemas/2.6.0:
+    resolution: {integrity: sha512-uUrgZ8AxS+Lio0fZKAipJjAh415JyrOZowliZAzmnJSsf7piVL5w+G0+gFJ0KSu3QRhvui/7zuvpLz03YjXAhg==}
+    dev: true
+
+  /accepts/1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+    dev: true
+
+  /acorn-jsx/5.3.2_acorn@8.7.1:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.7.1
+    dev: false
+
+  /acorn-walk/8.2.0:
+    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
+  /acorn/8.7.1:
+    resolution: {integrity: sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  /agent-base/6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /ajv/6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+    dev: true
+
+  /ansi-align/3.0.1:
+    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
+    dependencies:
+      string-width: 4.2.3
+    dev: true
+
+  /ansi-regex/5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /ansi-styles/3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+    dependencies:
+      color-convert: 1.9.3
+    dev: true
+
+  /ansi-styles/4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      color-convert: 2.0.1
+    dev: true
+
+  /anymatch/3.1.2:
+    resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+
+  /arch/2.2.0:
+    resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
+    dev: true
+
+  /arg/2.0.0:
+    resolution: {integrity: sha512-XxNTUzKnz1ctK3ZIcI2XUPlD96wbHP2nGqkPKpvk/HNRlPveYrXIVSTk9m3LcqOgDPg3B1nMvdV/K8wZd7PG4w==}
+    dev: true
+
+  /arg/4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    dev: true
+
+  /argparse/1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+    dependencies:
+      sprintf-js: 1.0.3
+    dev: true
+
+  /astring/1.8.3:
+    resolution: {integrity: sha512-sRpyiNrx2dEYIMmUXprS8nlpRg2Drs8m9ElX9vVEXaCB4XEAJhKfs7IcX0IwShjuOAjLR6wzIrgoptz1n19i1A==}
+    hasBin: true
+    dev: false
+
+  /bail/2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+    dev: false
+
+  /balanced-match/1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: true
+
+  /base64-js/1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: true
+
+  /binary-extensions/2.2.0:
+    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
+    engines: {node: '>=8'}
+
+  /bl/4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.0
+    dev: true
+
+  /boxen/5.1.2:
+    resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-align: 3.0.1
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      cli-boxes: 2.2.1
+      string-width: 4.2.3
+      type-fest: 0.20.2
+      widest-line: 3.1.0
+      wrap-ansi: 7.0.0
+    dev: true
+
+  /brace-expansion/1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    dev: true
+
+  /braces/3.0.2:
+    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+    engines: {node: '>=8'}
+    dependencies:
+      fill-range: 7.0.1
+
+  /buffer-crc32/0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+    dev: true
+
+  /buffer/5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    dev: true
+
+  /builtin-modules/1.1.1:
+    resolution: {integrity: sha512-wxXCdllwGhI2kCC0MnvTGYTMvnVZTvqgypkiTI8Pa5tcz2i6VqsqwYGgqwXji+4RgCzms6EajE4IxiUH6HH8nQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /bytes/3.0.0:
+    resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
+  /camelcase/6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /caniuse-lite/1.0.30001363:
+    resolution: {integrity: sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg==}
+    dev: false
+
+  /ccount/2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+    dev: false
+
+  /chalk/2.4.1:
+    resolution: {integrity: sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==}
+    engines: {node: '>=4'}
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+    dev: true
+
+  /chalk/2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+    dev: true
+
+  /chalk/4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+    dev: true
+
+  /character-entities-html4/2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+    dev: false
+
+  /character-entities-legacy/3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+    dev: false
+
+  /character-entities/2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+    dev: false
+
+  /character-reference-invalid/2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+    dev: false
+
+  /chokidar/3.5.3:
+    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+    engines: {node: '>= 8.10.0'}
+    dependencies:
+      anymatch: 3.1.2
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  /chownr/1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+    dev: true
+
+  /cli-boxes/2.2.1:
+    resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /clipboardy/2.3.0:
+    resolution: {integrity: sha512-mKhiIL2DrQIsuXMgBgnfEHOZOryC7kY7YO//TN6c63wlEm3NG5tz+YgY5rVi29KCmq/QQjKYvM7a19+MDOTHOQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      arch: 2.2.0
+      execa: 1.0.0
+      is-wsl: 2.2.0
+    dev: true
+
+  /color-convert/1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    dependencies:
+      color-name: 1.1.3
+    dev: true
+
+  /color-convert/2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+    dependencies:
+      color-name: 1.1.4
+    dev: true
+
+  /color-name/1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+    dev: true
+
+  /color-name/1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: true
+
+  /comma-separated-tokens/2.0.2:
+    resolution: {integrity: sha512-G5yTt3KQN4Yn7Yk4ed73hlZ1evrFKXeUW3086p3PRFNp7m2vIjI6Pg+Kgb+oyzhd9F2qdcoj67+y3SdxL5XWsg==}
+    dev: false
+
+  /commander/2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+    dev: true
+
+  /compressible/2.0.18:
+    resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: true
+
+  /compression/1.7.3:
+    resolution: {integrity: sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      accepts: 1.3.8
+      bytes: 3.0.0
+      compressible: 2.0.18
+      debug: 2.6.9
+      on-headers: 1.0.2
+      safe-buffer: 5.1.2
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /concat-map/0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: true
+
+  /content-disposition/0.5.2:
+    resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /create-require/1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
+
+  /cross-fetch/3.1.5:
+    resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
+    dependencies:
+      node-fetch: 2.6.7
+    transitivePeerDependencies:
+      - encoding
+    dev: true
+
+  /cross-spawn/6.0.5:
+    resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
+    engines: {node: '>=4.8'}
+    dependencies:
+      nice-try: 1.0.5
+      path-key: 2.0.1
+      semver: 5.7.1
+      shebang-command: 1.2.0
+      which: 1.3.1
+    dev: true
+
+  /csstype/3.1.0:
+    resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
+
+  /debug/2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.0.0
+    dev: true
+
+  /debug/4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+
+  /decode-named-character-reference/1.0.2:
+    resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
+    dependencies:
+      character-entities: 2.0.2
+    dev: false
+
+  /deep-extend/0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+    dev: true
+
+  /dequal/2.0.2:
+    resolution: {integrity: sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /devtools-protocol/0.0.981744:
+    resolution: {integrity: sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==}
+    dev: true
+
+  /diff/4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+    dev: true
+
+  /diff/5.1.0:
+    resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
+    engines: {node: '>=0.3.1'}
+    dev: false
+
+  /emoji-regex/8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    dev: true
+
+  /end-of-stream/1.4.4:
+    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+    dependencies:
+      once: 1.4.0
+    dev: true
+
+  /enhanced-resolve/5.10.0:
+    resolution: {integrity: sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==}
+    engines: {node: '>=10.13.0'}
+    dependencies:
+      graceful-fs: 4.2.10
+      tapable: 2.2.1
+    dev: true
+
+  /escape-string-regexp/1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+    dev: true
+
+  /esprima/4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: true
+
+  /estree-util-attach-comments/2.0.1:
+    resolution: {integrity: sha512-1wTBNndwMIsnvnuxjFIaYQz0M7PsCvcgP0YD7/dU8xWh1FuHk+O6pYpT4sLa5THY/CywJvdIdgw4uhozujga/g==}
+    dependencies:
+      '@types/estree': 0.0.51
+    dev: false
+
+  /estree-util-build-jsx/2.1.0:
+    resolution: {integrity: sha512-gsBGfsY6LOJUIDwmMkTOcgCX+3r/LUjRBccgHMSW55PHjhZsV13RmPl/iwpAvW8KcQqoN9P0FEFWTSS2Zc5bGA==}
+    dependencies:
+      '@types/estree-jsx': 0.0.1
+      estree-util-is-identifier-name: 2.0.1
+      estree-walker: 3.0.1
+    dev: false
+
+  /estree-util-is-identifier-name/2.0.1:
+    resolution: {integrity: sha512-rxZj1GkQhY4x1j/CSnybK9cGuMFQYFPLq0iNyopqf14aOVLFtMv7Esika+ObJWPWiOHuMOAHz3YkWoLYYRnzWQ==}
+    dev: false
+
+  /estree-util-visit/1.1.0:
+    resolution: {integrity: sha512-3lXJ4Us9j8TUif9cWcQy81t9p5OLasnDuuhrFiqb+XstmKC1d1LmrQWYsY49/9URcfHE64mPypDBaNK9NwWDPQ==}
+    dependencies:
+      '@types/estree-jsx': 0.0.1
+      '@types/unist': 2.0.6
+    dev: false
+
+  /estree-walker/3.0.1:
+    resolution: {integrity: sha512-woY0RUD87WzMBUiZLx8NsYr23N5BKsOMZHhu2hoNRVh6NXGfoiT1KOL8G3UHlJAnEDGmfa5ubNA/AacfG+Kb0g==}
+    dev: false
+
+  /execa/1.0.0:
+    resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
+    engines: {node: '>=6'}
+    dependencies:
+      cross-spawn: 6.0.5
+      get-stream: 4.1.0
+      is-stream: 1.1.0
+      npm-run-path: 2.0.2
+      p-finally: 1.0.0
+      signal-exit: 3.0.7
+      strip-eof: 1.0.0
+    dev: true
+
+  /extend/3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    dev: false
+
+  /extract-zip/2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+    dependencies:
+      debug: 4.3.4
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /fast-deep-equal/3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: true
+
+  /fast-json-stable-stringify/2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+    dev: true
+
+  /fast-url-parser/1.1.3:
+    resolution: {integrity: sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==}
+    dependencies:
+      punycode: 1.4.1
+    dev: true
+
+  /fd-slicer/1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+    dependencies:
+      pend: 1.2.0
+    dev: true
+
+  /fill-range/7.0.1:
+    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      to-regex-range: 5.0.1
+
+  /find-up/4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+    dev: true
+
+  /fs-constants/1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+    dev: true
+
+  /fs.realpath/1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: true
+
+  /fsevents/2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
+  /function-bind/1.1.1:
+    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+    dev: true
+
+  /get-stream/4.1.0:
+    resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
+    engines: {node: '>=6'}
+    dependencies:
+      pump: 3.0.0
+    dev: true
+
+  /get-stream/5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+    dependencies:
+      pump: 3.0.0
+    dev: true
+
+  /glob-parent/5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+    dependencies:
+      is-glob: 4.0.3
+
+  /glob/7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: true
+
+  /graceful-fs/4.2.10:
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
+    dev: true
+
+  /has-flag/3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /has-flag/4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /has/1.0.3:
+    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
+    engines: {node: '>= 0.4.0'}
+    dependencies:
+      function-bind: 1.1.1
+    dev: true
+
+  /hast-util-to-estree/2.0.2:
+    resolution: {integrity: sha512-UQrZVeBj6A9od0lpFvqHKNSH9zvDrNoyWKbveu1a2oSCXEDUI+3bnd6BoiQLPnLrcXXn/jzJ6y9hmJTTlvf8lQ==}
+    dependencies:
+      '@types/estree-jsx': 0.0.1
+      '@types/hast': 2.3.4
+      '@types/unist': 2.0.6
+      comma-separated-tokens: 2.0.2
+      estree-util-attach-comments: 2.0.1
+      estree-util-is-identifier-name: 2.0.1
+      hast-util-whitespace: 2.0.0
+      mdast-util-mdx-expression: 1.2.1
+      mdast-util-mdxjs-esm: 1.2.0
+      property-information: 6.1.1
+      space-separated-tokens: 2.0.1
+      style-to-object: 0.3.0
+      unist-util-position: 4.0.3
+      zwitch: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /hast-util-whitespace/2.0.0:
+    resolution: {integrity: sha512-Pkw+xBHuV6xFeJprJe2BBEoDV+AvQySaz3pPDRUs5PNZEMQjpXJJueqrpcHIXxnWTcAGi/UOCgVShlkY6kLoqg==}
+    dev: false
+
+  /https-proxy-agent/5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /ieee754/1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    dev: true
+
+  /immutable/4.1.0:
+    resolution: {integrity: sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==}
+
+  /inflight/1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    dev: true
+
+  /inherits/2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: true
+
+  /ini/1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+    dev: true
+
+  /inline-style-parser/0.1.1:
+    resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
+    dev: false
+
+  /is-alphabetical/2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+    dev: false
+
+  /is-alphanumerical/2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+    dev: false
+
+  /is-binary-path/2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+    dependencies:
+      binary-extensions: 2.2.0
+
+  /is-buffer/2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /is-core-module/2.9.0:
+    resolution: {integrity: sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==}
+    dependencies:
+      has: 1.0.3
+    dev: true
+
+  /is-decimal/2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+    dev: false
+
+  /is-docker/2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dev: true
+
+  /is-extglob/2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  /is-fullwidth-code-point/3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /is-glob/4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extglob: 2.1.1
+
+  /is-hexadecimal/2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+    dev: false
+
+  /is-number/7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  /is-plain-obj/4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /is-reference/3.0.0:
+    resolution: {integrity: sha512-Eo1W3wUoHWoCoVM4GVl/a+K0IgiqE5aIo4kJABFyMum1ZORlPkC+UC357sSQUL5w5QCE5kCC9upl75b7+7CY/Q==}
+    dependencies:
+      '@types/estree': 0.0.52
+    dev: false
+
+  /is-stream/1.1.0:
+    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-wsl/2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+    dependencies:
+      is-docker: 2.2.1
+    dev: true
+
+  /isexe/2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: true
+
+  /js-tokens/4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  /js-yaml/3.14.1:
+    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+    dev: true
+
+  /json-schema-traverse/0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    dev: true
+
+  /kleur/4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /locate-path/5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-locate: 4.1.0
+    dev: true
+
+  /longest-streak/3.0.1:
+    resolution: {integrity: sha512-cHlYSUpL2s7Fb3394mYxwTYj8niTaNHUCLr0qdiCXQfSjfuA7CKofpX2uSwEfFDQ0EB7JcnMnm+GjbqqoinYYg==}
+    dev: false
+
+  /loose-envify/1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: false
+
+  /lru-cache/6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+    dependencies:
+      yallist: 4.0.0
+    dev: true
+
+  /make-error/1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: true
+
+  /markdown-extensions/1.1.1:
+    resolution: {integrity: sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /mdast-util-definitions/5.1.1:
+    resolution: {integrity: sha512-rQ+Gv7mHttxHOBx2dkF4HWTg+EE+UR78ptQWDylzPKaQuVGdG4HIoY3SrS/pCp80nZ04greFvXbVFHT+uf0JVQ==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      '@types/unist': 2.0.6
+      unist-util-visit: 4.1.0
+    dev: false
+
+  /mdast-util-from-markdown/1.2.0:
+    resolution: {integrity: sha512-iZJyyvKD1+K7QX1b5jXdE7Sc5dtoTry1vzV28UZZe8Z1xVnB/czKntJ7ZAkG0tANqRnBF6p3p7GpU1y19DTf2Q==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      '@types/unist': 2.0.6
+      decode-named-character-reference: 1.0.2
+      mdast-util-to-string: 3.1.0
+      micromark: 3.0.10
+      micromark-util-decode-numeric-character-reference: 1.0.0
+      micromark-util-decode-string: 1.0.2
+      micromark-util-normalize-identifier: 1.0.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      unist-util-stringify-position: 3.0.2
+      uvu: 0.5.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-mdx-expression/1.2.1:
+    resolution: {integrity: sha512-BtQwyalaq6jRjx0pagtuAwGrmzL1yInrfA4EJv7GOoiPOUbR4gr6h65I+G3WTh1/Cag2Eda4ip400Ch6CFmWiA==}
+    dependencies:
+      '@types/estree-jsx': 0.0.1
+      '@types/hast': 2.3.4
+      '@types/mdast': 3.0.10
+      mdast-util-from-markdown: 1.2.0
+      mdast-util-to-markdown: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-mdx-jsx/2.0.1:
+    resolution: {integrity: sha512-oPC7/smPBf7vxnvIYH5y3fPo2lw1rdrswFfSb4i0GTAXRUQv7JUU/t/hbp07dgGdUFTSDOHm5DNamhNg/s2Hrg==}
+    dependencies:
+      '@types/estree-jsx': 0.0.1
+      '@types/hast': 2.3.4
+      '@types/mdast': 3.0.10
+      ccount: 2.0.1
+      mdast-util-to-markdown: 1.3.0
+      parse-entities: 4.0.0
+      stringify-entities: 4.0.3
+      unist-util-remove-position: 4.0.1
+      unist-util-stringify-position: 3.0.2
+      vfile-message: 3.1.2
+    dev: false
+
+  /mdast-util-mdx/2.0.0:
+    resolution: {integrity: sha512-M09lW0CcBT1VrJUaF/PYxemxxHa7SLDHdSn94Q9FhxjCQfuW7nMAWKWimTmA3OyDMSTH981NN1csW1X+HPSluw==}
+    dependencies:
+      mdast-util-mdx-expression: 1.2.1
+      mdast-util-mdx-jsx: 2.0.1
+      mdast-util-mdxjs-esm: 1.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-mdxjs-esm/1.2.0:
+    resolution: {integrity: sha512-IPpX9GBzAIbIRCjbyeLDpMhACFb0wxTIujuR3YElB8LWbducUdMgRJuqs/Vg8xQ1bIAMm7lw8L+YNtua0xKXRw==}
+    dependencies:
+      '@types/estree-jsx': 0.0.1
+      '@types/hast': 2.3.4
+      '@types/mdast': 3.0.10
+      mdast-util-from-markdown: 1.2.0
+      mdast-util-to-markdown: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-to-hast/12.1.2:
+    resolution: {integrity: sha512-Wn6Mcj04qU4qUXHnHpPATYMH2Jd8RlntdnloDfYLe1ErWRHo6+pvSl/DzHp6sCZ9cBSYlc8Sk8pbwb8xtUoQhQ==}
+    dependencies:
+      '@types/hast': 2.3.4
+      '@types/mdast': 3.0.10
+      '@types/mdurl': 1.0.2
+      mdast-util-definitions: 5.1.1
+      mdurl: 1.0.1
+      micromark-util-sanitize-uri: 1.0.0
+      trim-lines: 3.0.1
+      unist-builder: 3.0.0
+      unist-util-generated: 2.0.0
+      unist-util-position: 4.0.3
+      unist-util-visit: 4.1.0
+    dev: false
+
+  /mdast-util-to-markdown/1.3.0:
+    resolution: {integrity: sha512-6tUSs4r+KK4JGTTiQ7FfHmVOaDrLQJPmpjD6wPMlHGUVXoG9Vjc3jIeP+uyBWRf8clwB2blM+W7+KrlMYQnftA==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      '@types/unist': 2.0.6
+      longest-streak: 3.0.1
+      mdast-util-to-string: 3.1.0
+      micromark-util-decode-string: 1.0.2
+      unist-util-visit: 4.1.0
+      zwitch: 2.0.2
+    dev: false
+
+  /mdast-util-to-string/3.1.0:
+    resolution: {integrity: sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==}
+    dev: false
+
+  /mdurl/1.0.1:
+    resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
+    dev: false
+
+  /micromark-core-commonmark/1.0.6:
+    resolution: {integrity: sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==}
+    dependencies:
+      decode-named-character-reference: 1.0.2
+      micromark-factory-destination: 1.0.0
+      micromark-factory-label: 1.0.2
+      micromark-factory-space: 1.0.0
+      micromark-factory-title: 1.0.2
+      micromark-factory-whitespace: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-chunked: 1.0.0
+      micromark-util-classify-character: 1.0.0
+      micromark-util-html-tag-name: 1.1.0
+      micromark-util-normalize-identifier: 1.0.0
+      micromark-util-resolve-all: 1.0.0
+      micromark-util-subtokenize: 1.0.2
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-extension-mdx-expression/1.0.3:
+    resolution: {integrity: sha512-TjYtjEMszWze51NJCZmhv7MEBcgYRgb3tJeMAJ+HQCAaZHHRBaDCccqQzGizR/H4ODefP44wRTgOn2vE5I6nZA==}
+    dependencies:
+      micromark-factory-mdx-expression: 1.0.6
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-events-to-acorn: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-extension-mdx-jsx/1.0.3:
+    resolution: {integrity: sha512-VfA369RdqUISF0qGgv2FfV7gGjHDfn9+Qfiv5hEwpyr1xscRj/CiVRkU7rywGFCO7JwJ5L0e7CJz60lY52+qOA==}
+    dependencies:
+      '@types/acorn': 4.0.6
+      estree-util-is-identifier-name: 2.0.1
+      micromark-factory-mdx-expression: 1.0.6
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+      vfile-message: 3.1.2
+    dev: false
+
+  /micromark-extension-mdx-md/1.0.0:
+    resolution: {integrity: sha512-xaRAMoSkKdqZXDAoSgp20Azm0aRQKGOl0RrS81yGu8Hr/JhMsBmfs4wR7m9kgVUIO36cMUQjNyiyDKPrsv8gOw==}
+    dependencies:
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-extension-mdxjs-esm/1.0.3:
+    resolution: {integrity: sha512-2N13ol4KMoxb85rdDwTAC6uzs8lMX0zeqpcyx7FhS7PxXomOnLactu8WI8iBNXW8AVyea3KIJd/1CKnUmwrK9A==}
+    dependencies:
+      micromark-core-commonmark: 1.0.6
+      micromark-util-character: 1.1.0
+      micromark-util-events-to-acorn: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      unist-util-position-from-estree: 1.1.1
+      uvu: 0.5.6
+      vfile-message: 3.1.2
+    dev: false
+
+  /micromark-extension-mdxjs/1.0.0:
+    resolution: {integrity: sha512-TZZRZgeHvtgm+IhtgC2+uDMR7h8eTKF0QUX9YsgoL9+bADBpBY6SiLvWqnBlLbCEevITmTqmEuY3FoxMKVs1rQ==}
+    dependencies:
+      acorn: 8.7.1
+      acorn-jsx: 5.3.2_acorn@8.7.1
+      micromark-extension-mdx-expression: 1.0.3
+      micromark-extension-mdx-jsx: 1.0.3
+      micromark-extension-mdx-md: 1.0.0
+      micromark-extension-mdxjs-esm: 1.0.3
+      micromark-util-combine-extensions: 1.0.0
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-factory-destination/1.0.0:
+    resolution: {integrity: sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-factory-label/1.0.2:
+    resolution: {integrity: sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-factory-mdx-expression/1.0.6:
+    resolution: {integrity: sha512-WRQIc78FV7KrCfjsEf/sETopbYjElh3xAmNpLkd1ODPqxEngP42eVRGbiPEQWpRV27LzqW+XVTvQAMIIRLPnNA==}
+    dependencies:
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-events-to-acorn: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      unist-util-position-from-estree: 1.1.1
+      uvu: 0.5.6
+      vfile-message: 3.1.2
+    dev: false
+
+  /micromark-factory-space/1.0.0:
+    resolution: {integrity: sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-factory-title/1.0.2:
+    resolution: {integrity: sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==}
+    dependencies:
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-factory-whitespace/1.0.0:
+    resolution: {integrity: sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==}
+    dependencies:
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-util-character/1.1.0:
+    resolution: {integrity: sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==}
+    dependencies:
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-util-chunked/1.0.0:
+    resolution: {integrity: sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==}
+    dependencies:
+      micromark-util-symbol: 1.0.1
+    dev: false
+
+  /micromark-util-classify-character/1.0.0:
+    resolution: {integrity: sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-util-combine-extensions/1.0.0:
+    resolution: {integrity: sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==}
+    dependencies:
+      micromark-util-chunked: 1.0.0
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-util-decode-numeric-character-reference/1.0.0:
+    resolution: {integrity: sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==}
+    dependencies:
+      micromark-util-symbol: 1.0.1
+    dev: false
+
+  /micromark-util-decode-string/1.0.2:
+    resolution: {integrity: sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==}
+    dependencies:
+      decode-named-character-reference: 1.0.2
+      micromark-util-character: 1.1.0
+      micromark-util-decode-numeric-character-reference: 1.0.0
+      micromark-util-symbol: 1.0.1
+    dev: false
+
+  /micromark-util-encode/1.0.1:
+    resolution: {integrity: sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA==}
+    dev: false
+
+  /micromark-util-events-to-acorn/1.1.0:
+    resolution: {integrity: sha512-hB8HzidNt/Us5q2BvqXj8eeEm0U9rRfnZxcA9T65JRUMAY4MbfJRAFm7m9fXMAdSHJiVPmajsp8/rp6/FlHL8A==}
+    dependencies:
+      '@types/acorn': 4.0.6
+      '@types/estree': 0.0.51
+      estree-util-visit: 1.1.0
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+      vfile-location: 4.0.1
+      vfile-message: 3.1.2
+    dev: false
+
+  /micromark-util-html-tag-name/1.1.0:
+    resolution: {integrity: sha512-BKlClMmYROy9UiV03SwNmckkjn8QHVaWkqoAqzivabvdGcwNGMMMH/5szAnywmsTBUzDsU57/mFi0sp4BQO6dA==}
+    dev: false
+
+  /micromark-util-normalize-identifier/1.0.0:
+    resolution: {integrity: sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==}
+    dependencies:
+      micromark-util-symbol: 1.0.1
+    dev: false
+
+  /micromark-util-resolve-all/1.0.0:
+    resolution: {integrity: sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==}
+    dependencies:
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-util-sanitize-uri/1.0.0:
+    resolution: {integrity: sha512-cCxvBKlmac4rxCGx6ejlIviRaMKZc0fWm5HdCHEeDWRSkn44l6NdYVRyU+0nT1XC72EQJMZV8IPHF+jTr56lAg==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-encode: 1.0.1
+      micromark-util-symbol: 1.0.1
+    dev: false
+
+  /micromark-util-subtokenize/1.0.2:
+    resolution: {integrity: sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==}
+    dependencies:
+      micromark-util-chunked: 1.0.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-util-symbol/1.0.1:
+    resolution: {integrity: sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==}
+    dev: false
+
+  /micromark-util-types/1.0.2:
+    resolution: {integrity: sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==}
+    dev: false
+
+  /micromark/3.0.10:
+    resolution: {integrity: sha512-ryTDy6UUunOXy2HPjelppgJ2sNfcPz1pLlMdA6Rz9jPzhLikWXv/irpWV/I2jd68Uhmny7hHxAlAhk4+vWggpg==}
+    dependencies:
+      '@types/debug': 4.1.7
+      debug: 4.3.4
+      decode-named-character-reference: 1.0.2
+      micromark-core-commonmark: 1.0.6
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-chunked: 1.0.0
+      micromark-util-combine-extensions: 1.0.0
+      micromark-util-decode-numeric-character-reference: 1.0.0
+      micromark-util-encode: 1.0.1
+      micromark-util-normalize-identifier: 1.0.0
+      micromark-util-resolve-all: 1.0.0
+      micromark-util-sanitize-uri: 1.0.0
+      micromark-util-subtokenize: 1.0.2
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /micromatch/4.0.5:
+    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
+    engines: {node: '>=8.6'}
+    dependencies:
+      braces: 3.0.2
+      picomatch: 2.3.1
+    dev: true
+
+  /mime-db/1.33.0:
+    resolution: {integrity: sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /mime-db/1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /mime-types/2.1.18:
+    resolution: {integrity: sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.33.0
+    dev: true
+
+  /mime-types/2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: true
+
+  /minimatch/3.0.4:
+    resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
+    dependencies:
+      brace-expansion: 1.1.11
+    dev: true
+
+  /minimatch/3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+    dependencies:
+      brace-expansion: 1.1.11
+    dev: true
+
+  /minimist/1.2.6:
+    resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
+    dev: true
+
+  /mkdirp-classic/0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+    dev: true
+
+  /mkdirp/0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.6
+    dev: true
+
+  /mri/1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /ms/2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+    dev: true
+
+  /ms/2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
+  /nanoid/3.3.4:
+    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: false
+
+  /negotiator/0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /next/12.2.0_352uutu4og2bvewd2z7ffpt77y:
+    resolution: {integrity: sha512-B4j7D3SHYopLYx6/Ark0fenwIar9tEaZZFAaxmKjgcMMexhVJzB3jt7X+6wcdXPPMeUD6r09weUtnDpjox/vIA==}
+    engines: {node: '>=12.22.0'}
+    hasBin: true
+    peerDependencies:
+      fibers: '>= 3.1.0'
+      node-sass: ^6.0.0 || ^7.0.0
+      react: ^17.0.2 || ^18.0.0-0
+      react-dom: ^17.0.2 || ^18.0.0-0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      fibers:
+        optional: true
+      node-sass:
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 12.2.0
+      '@swc/helpers': 0.4.2
+      caniuse-lite: 1.0.30001363
+      postcss: 8.4.5
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      sass: 1.53.0
+      styled-jsx: 5.0.2_react@17.0.2
+      use-sync-external-store: 1.1.0_react@17.0.2
+    optionalDependencies:
+      '@next/swc-android-arm-eabi': 12.2.0
+      '@next/swc-android-arm64': 12.2.0
+      '@next/swc-darwin-arm64': 12.2.0
+      '@next/swc-darwin-x64': 12.2.0
+      '@next/swc-freebsd-x64': 12.2.0
+      '@next/swc-linux-arm-gnueabihf': 12.2.0
+      '@next/swc-linux-arm64-gnu': 12.2.0
+      '@next/swc-linux-arm64-musl': 12.2.0
+      '@next/swc-linux-x64-gnu': 12.2.0
+      '@next/swc-linux-x64-musl': 12.2.0
+      '@next/swc-win32-arm64-msvc': 12.2.0
+      '@next/swc-win32-ia32-msvc': 12.2.0
+      '@next/swc-win32-x64-msvc': 12.2.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    dev: false
+
+  /nice-try/1.0.5:
+    resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
+    dev: true
+
+  /node-fetch/2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: true
+
+  /normalize-path/3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  /npm-run-path/2.0.2:
+    resolution: {integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==}
+    engines: {node: '>=4'}
+    dependencies:
+      path-key: 2.0.1
+    dev: true
+
+  /object-assign/4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /on-headers/1.0.2:
+    resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
+  /once/1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+    dependencies:
+      wrappy: 1.0.2
+    dev: true
+
+  /p-finally/1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /p-limit/2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+    dependencies:
+      p-try: 2.2.0
+    dev: true
+
+  /p-locate/4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-limit: 2.3.0
+    dev: true
+
+  /p-try/2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /parse-entities/4.0.0:
+    resolution: {integrity: sha512-5nk9Fn03x3rEhGaX1FU6IDwG/k+GxLXlFAkgrbM1asuAFl3BhdQWvASaIsmwWypRNcZKHPYnIuOSfIWEyEQnPQ==}
+    dependencies:
+      '@types/unist': 2.0.6
+      character-entities: 2.0.2
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.0.2
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+    dev: false
+
+  /path-exists/4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /path-is-absolute/1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /path-is-inside/1.0.2:
+    resolution: {integrity: sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==}
+    dev: true
+
+  /path-key/2.0.1:
+    resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /path-parse/1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    dev: true
+
+  /path-to-regexp/2.2.1:
+    resolution: {integrity: sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==}
+    dev: true
+
+  /pend/1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+    dev: true
+
+  /periscopic/3.0.4:
+    resolution: {integrity: sha512-SFx68DxCv0Iyo6APZuw/AKewkkThGwssmU0QWtTlvov3VAtPX+QJ4CadwSaz8nrT5jPIuxdvJWB4PnD2KNDxQg==}
+    dependencies:
+      estree-walker: 3.0.1
+      is-reference: 3.0.0
+    dev: false
+
+  /picocolors/1.0.0:
+    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    dev: false
+
+  /picomatch/2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
+  /pkg-dir/4.2.0:
+    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      find-up: 4.1.0
+    dev: true
+
+  /postcss/8.4.5:
+    resolution: {integrity: sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.4
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: false
+
+  /prettier/2.7.1:
+    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    dev: true
+
+  /prism-react-renderer/1.3.5_react@17.0.2:
+    resolution: {integrity: sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==}
+    peerDependencies:
+      react: '>=0.14.9'
+    dependencies:
+      react: 17.0.2
+    dev: false
+
+  /progress/2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
+  /property-information/6.1.1:
+    resolution: {integrity: sha512-hrzC564QIl0r0vy4l6MvRLhafmUowhO/O3KgVSoXIbbA2Sz4j8HGpJc6T2cubRVwMwpdiG/vKGfhT4IixmKN9w==}
+    dev: false
+
+  /proxy-from-env/1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: true
+
+  /pump/3.0.0:
+    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
+    dependencies:
+      end-of-stream: 1.4.4
+      once: 1.4.0
+    dev: true
+
+  /punycode/1.4.1:
+    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
+    dev: true
+
+  /punycode/2.1.1:
+    resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /puppeteer/13.7.0:
+    resolution: {integrity: sha512-U1uufzBjz3+PkpCxFrWzh4OrMIdIb2ztzCu0YEPfRHjHswcSwHZswnK+WdsOQJsRV8WeTg3jLhJR4D867+fjsA==}
+    engines: {node: '>=10.18.1'}
+    requiresBuild: true
+    dependencies:
+      cross-fetch: 3.1.5
+      debug: 4.3.4
+      devtools-protocol: 0.0.981744
+      extract-zip: 2.0.1
+      https-proxy-agent: 5.0.1
+      pkg-dir: 4.2.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      rimraf: 3.0.2
+      tar-fs: 2.1.1
+      unbzip2-stream: 1.4.3
+      ws: 8.5.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /range-parser/1.2.0:
+    resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /rc/1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.6
+      strip-json-comments: 2.0.1
+    dev: true
+
+  /react-dom/17.0.2_react@17.0.2:
+    resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
+    peerDependencies:
+      react: 17.0.2
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react: 17.0.2
+      scheduler: 0.20.2
+    dev: false
+
+  /react/17.0.2:
+    resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+    dev: false
+
+  /readable-stream/3.6.0:
+    resolution: {integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==}
+    engines: {node: '>= 6'}
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    dev: true
+
+  /readdirp/3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      picomatch: 2.3.1
+
+  /registry-auth-token/3.3.2:
+    resolution: {integrity: sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==}
+    dependencies:
+      rc: 1.2.8
+      safe-buffer: 5.2.1
+    dev: true
+
+  /registry-url/3.1.0:
+    resolution: {integrity: sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      rc: 1.2.8
+    dev: true
+
+  /remark-mdx/2.1.2:
+    resolution: {integrity: sha512-npQagPdczPAv0xN9F8GSi5hJfAe/z6nBjylyfOfjLOmz086ahWrIjlk4BulRfNhA+asutqWxyuT3DFVsxiTVHA==}
+    dependencies:
+      mdast-util-mdx: 2.0.0
+      micromark-extension-mdxjs: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /remark-parse/10.0.1:
+    resolution: {integrity: sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      mdast-util-from-markdown: 1.2.0
+      unified: 10.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /remark-rehype/10.1.0:
+    resolution: {integrity: sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==}
+    dependencies:
+      '@types/hast': 2.3.4
+      '@types/mdast': 3.0.10
+      mdast-util-to-hast: 12.1.2
+      unified: 10.1.2
+    dev: false
+
+  /resolve/1.22.1:
+    resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.9.0
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: true
+
+  /rimraf/3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    hasBin: true
+    dependencies:
+      glob: 7.2.3
+    dev: true
+
+  /sade/1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+    dependencies:
+      mri: 1.2.0
+    dev: false
+
+  /safe-buffer/5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+    dev: true
+
+  /safe-buffer/5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: true
+
+  /sass/1.53.0:
+    resolution: {integrity: sha512-zb/oMirbKhUgRQ0/GFz8TSAwRq2IlR29vOUJZOx0l8sV+CkHUfHa4u5nqrG+1VceZp7Jfj59SVW9ogdhTvJDcQ==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+    dependencies:
+      chokidar: 3.5.3
+      immutable: 4.1.0
+      source-map-js: 1.0.2
+
+  /scheduler/0.20.2:
+    resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+    dev: false
+
+  /semver/5.7.1:
+    resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
+    hasBin: true
+    dev: true
+
+  /semver/7.3.7:
+    resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
+
+  /serve-handler/6.1.3:
+    resolution: {integrity: sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==}
+    dependencies:
+      bytes: 3.0.0
+      content-disposition: 0.5.2
+      fast-url-parser: 1.1.3
+      mime-types: 2.1.18
+      minimatch: 3.0.4
+      path-is-inside: 1.0.2
+      path-to-regexp: 2.2.1
+      range-parser: 1.2.0
+    dev: true
+
+  /serve/13.0.4:
+    resolution: {integrity: sha512-Lj8rhXmphJCRQVv5qwu0NQZ2h+0MrRyRJxDZu5y3qLH2i/XY6a0FPj/VmjMUdkJb672MBfE8hJ274PU6JzBd0Q==}
+    hasBin: true
+    dependencies:
+      '@zeit/schemas': 2.6.0
+      ajv: 6.12.6
+      arg: 2.0.0
+      boxen: 5.1.2
+      chalk: 2.4.1
+      clipboardy: 2.3.0
+      compression: 1.7.3
+      serve-handler: 6.1.3
+      update-check: 1.5.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /shebang-command/1.2.0:
+    resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      shebang-regex: 1.0.0
+    dev: true
+
+  /shebang-regex/1.0.0:
+    resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /signal-exit/3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+    dev: true
+
+  /source-map-js/1.0.2:
+    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
+    engines: {node: '>=0.10.0'}
+
+  /source-map/0.7.4:
+    resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
+    engines: {node: '>= 8'}
+    dev: false
+
+  /space-separated-tokens/2.0.1:
+    resolution: {integrity: sha512-ekwEbFp5aqSPKaqeY1PGrlGQxPNaq+Cnx4+bE2D8sciBQrHpbwoBbawqTN2+6jPs9IdWxxiUcN0K2pkczD3zmw==}
+    dev: false
+
+  /sprintf-js/1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    dev: true
+
+  /string-width/4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    dev: true
+
+  /string_decoder/1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
+
+  /stringify-entities/4.0.3:
+    resolution: {integrity: sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==}
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+    dev: false
+
+  /strip-ansi/6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-regex: 5.0.1
+    dev: true
+
+  /strip-eof/1.0.0:
+    resolution: {integrity: sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /strip-json-comments/2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /style-to-object/0.3.0:
+    resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
+    dependencies:
+      inline-style-parser: 0.1.1
+    dev: false
+
+  /styled-jsx/5.0.2_react@17.0.2:
+    resolution: {integrity: sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+    dependencies:
+      react: 17.0.2
+    dev: false
+
+  /supports-color/5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+    dependencies:
+      has-flag: 3.0.0
+    dev: true
+
+  /supports-color/7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: true
+
+  /supports-preserve-symlinks-flag/1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /tapable/2.2.1:
+    resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /tar-fs/2.1.1:
+    resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.0
+      tar-stream: 2.2.0
+    dev: true
+
+  /tar-stream/2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.4
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.0
+    dev: true
+
+  /through/2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+    dev: true
+
+  /to-regex-range/5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+    dependencies:
+      is-number: 7.0.0
+
+  /tr46/0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: true
+
+  /trim-lines/3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+    dev: false
+
+  /trough/2.1.0:
+    resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
+    dev: false
+
+  /ts-loader/9.3.1_typescript@4.7.4:
+    resolution: {integrity: sha512-OkyShkcZTsTwyS3Kt7a4rsT/t2qvEVQuKCTg4LJmpj9fhFR7ukGdZwV6Qq3tRUkqcXtfGpPR7+hFKHCG/0d3Lw==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      typescript: '*'
+      webpack: ^5.0.0
+    dependencies:
+      chalk: 4.1.2
+      enhanced-resolve: 5.10.0
+      micromatch: 4.0.5
+      semver: 7.3.7
+      typescript: 4.7.4
+    dev: true
+
+  /ts-node/10.8.2_typescript@4.7.4:
+    resolution: {integrity: sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      acorn: 8.7.1
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.7.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
+  /tslib/1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: true
+
+  /tslib/2.4.0:
+    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+    dev: false
+
+  /tslint-react/5.0.0_2d4q7cprazhk3fo4dnvjdmavtq:
+    resolution: {integrity: sha512-/IbcSmoBPlFic8kQaRfQ4knTY4mivwo5LVzvozvX6Dyu2ynEnrh1dIcR2ujjyp/IodXqY/H5GbxFxSMo/Kf2Hg==}
+    deprecated: tslint-react is deprecated along with TSLint
+    peerDependencies:
+      tslint: ^6.0.0
+      typescript: '>=3.4.1'
+    dependencies:
+      tslint: 6.1.3_typescript@4.7.4
+      tsutils: 3.21.0_typescript@4.7.4
+      typescript: 4.7.4
+    dev: true
+
+  /tslint/6.1.3_typescript@4.7.4:
+    resolution: {integrity: sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==}
+    engines: {node: '>=4.8.0'}
+    deprecated: TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.
+    hasBin: true
+    peerDependencies:
+      typescript: '>=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 4.0.0-dev'
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      builtin-modules: 1.1.1
+      chalk: 2.4.2
+      commander: 2.20.3
+      diff: 4.0.2
+      glob: 7.2.3
+      js-yaml: 3.14.1
+      minimatch: 3.1.2
+      mkdirp: 0.5.6
+      resolve: 1.22.1
+      semver: 5.7.1
+      tslib: 1.14.1
+      tsutils: 2.29.0_typescript@4.7.4
+      typescript: 4.7.4
+    dev: true
+
+  /tsutils/2.29.0_typescript@4.7.4:
+    resolution: {integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==}
+    peerDependencies:
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.7.4
+    dev: true
+
+  /tsutils/3.21.0_typescript@4.7.4:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.7.4
+    dev: true
+
+  /type-fest/0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /typescript/4.7.4:
+    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
+  /unbzip2-stream/1.4.3:
+    resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
+    dependencies:
+      buffer: 5.7.1
+      through: 2.3.8
+    dev: true
+
+  /unified/10.1.2:
+    resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}
+    dependencies:
+      '@types/unist': 2.0.6
+      bail: 2.0.2
+      extend: 3.0.2
+      is-buffer: 2.0.5
+      is-plain-obj: 4.1.0
+      trough: 2.1.0
+      vfile: 5.3.4
+    dev: false
+
+  /unist-builder/3.0.0:
+    resolution: {integrity: sha512-GFxmfEAa0vi9i5sd0R2kcrI9ks0r82NasRq5QHh2ysGngrc6GiqD5CDf1FjPenY4vApmFASBIIlk/jj5J5YbmQ==}
+    dependencies:
+      '@types/unist': 2.0.6
+    dev: false
+
+  /unist-util-generated/2.0.0:
+    resolution: {integrity: sha512-TiWE6DVtVe7Ye2QxOVW9kqybs6cZexNwTwSMVgkfjEReqy/xwGpAXb99OxktoWwmL+Z+Epb0Dn8/GNDYP1wnUw==}
+    dev: false
+
+  /unist-util-is/5.1.1:
+    resolution: {integrity: sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==}
+    dev: false
+
+  /unist-util-position-from-estree/1.1.1:
+    resolution: {integrity: sha512-xtoY50b5+7IH8tFbkw64gisG9tMSpxDjhX9TmaJJae/XuxQ9R/Kc8Nv1eOsf43Gt4KV/LkriMy9mptDr7XLcaw==}
+    dependencies:
+      '@types/unist': 2.0.6
+    dev: false
+
+  /unist-util-position/4.0.3:
+    resolution: {integrity: sha512-p/5EMGIa1qwbXjA+QgcBXaPWjSnZfQ2Sc3yBEEfgPwsEmJd8Qh+DSk3LGnmOM4S1bY2C0AjmMnB8RuEYxpPwXQ==}
+    dependencies:
+      '@types/unist': 2.0.6
+    dev: false
+
+  /unist-util-remove-position/4.0.1:
+    resolution: {integrity: sha512-0yDkppiIhDlPrfHELgB+NLQD5mfjup3a8UYclHruTJWmY74je8g+CIFr79x5f6AkmzSwlvKLbs63hC0meOMowQ==}
+    dependencies:
+      '@types/unist': 2.0.6
+      unist-util-visit: 4.1.0
+    dev: false
+
+  /unist-util-stringify-position/3.0.2:
+    resolution: {integrity: sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==}
+    dependencies:
+      '@types/unist': 2.0.6
+    dev: false
+
+  /unist-util-visit-parents/5.1.0:
+    resolution: {integrity: sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==}
+    dependencies:
+      '@types/unist': 2.0.6
+      unist-util-is: 5.1.1
+    dev: false
+
+  /unist-util-visit/4.1.0:
+    resolution: {integrity: sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==}
+    dependencies:
+      '@types/unist': 2.0.6
+      unist-util-is: 5.1.1
+      unist-util-visit-parents: 5.1.0
+    dev: false
+
+  /update-check/1.5.2:
+    resolution: {integrity: sha512-1TrmYLuLj/5ZovwUS7fFd1jMH3NnFDN1y1A8dboedIDt7zs/zJMo6TwwlhYKkSeEwzleeiSBV5/3c9ufAQWDaQ==}
+    dependencies:
+      registry-auth-token: 3.3.2
+      registry-url: 3.1.0
+    dev: true
+
+  /uri-js/4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    dependencies:
+      punycode: 2.1.1
+    dev: true
+
+  /use-sync-external-store/1.1.0_react@17.0.2:
+    resolution: {integrity: sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 17.0.2
+    dev: false
+
+  /util-deprecate/1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: true
+
+  /uvu/0.5.6:
+    resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      dequal: 2.0.2
+      diff: 5.1.0
+      kleur: 4.1.5
+      sade: 1.8.1
+    dev: false
+
+  /v8-compile-cache-lib/3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: true
+
+  /vary/1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
+  /vfile-location/4.0.1:
+    resolution: {integrity: sha512-JDxPlTbZrZCQXogGheBHjbRWjESSPEak770XwWPfw5mTc1v1nWGLB/apzZxsx8a0SJVfF8HK8ql8RD308vXRUw==}
+    dependencies:
+      '@types/unist': 2.0.6
+      vfile: 5.3.4
+    dev: false
+
+  /vfile-message/3.1.2:
+    resolution: {integrity: sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==}
+    dependencies:
+      '@types/unist': 2.0.6
+      unist-util-stringify-position: 3.0.2
+    dev: false
+
+  /vfile/5.3.4:
+    resolution: {integrity: sha512-KI+7cnst03KbEyN1+JE504zF5bJBZa+J+CrevLeyIMq0aPU681I2rQ5p4PlnQ6exFtWiUrg26QUdFMnAKR6PIw==}
+    dependencies:
+      '@types/unist': 2.0.6
+      is-buffer: 2.0.5
+      unist-util-stringify-position: 3.0.2
+      vfile-message: 3.1.2
+    dev: false
+
+  /webidl-conversions/3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: true
+
+  /whatwg-url/5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    dev: true
+
+  /which/1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+    dependencies:
+      isexe: 2.0.0
+    dev: true
+
+  /widest-line/3.1.0:
+    resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
+    engines: {node: '>=8'}
+    dependencies:
+      string-width: 4.2.3
+    dev: true
+
+  /wrap-ansi/7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+    dev: true
+
+  /wrappy/1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: true
+
+  /ws/8.5.0:
+    resolution: {integrity: sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: true
+
+  /yallist/4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: true
+
+  /yauzl/2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+    dev: true
+
+  /yn/3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /zwitch/2.0.2:
+    resolution: {integrity: sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA==}
+    dev: false

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -2,4 +2,5 @@ module.exports = {
     printWidth: 120,
     singleQuote: true,
     tabWidth: 4,
-};
+    semi: true,
+}

--- a/utils/removeIndent.ts
+++ b/utils/removeIndent.ts
@@ -1,0 +1,15 @@
+export function removeIndent(str: TemplateStringsArray) {
+    const lines = str[0].split('\n')
+
+    const cleanLines: String[] = lines
+        .map((line) => {
+            if (line !== '\n') {
+                return line
+            }
+        })
+        .filter(Boolean)
+
+    const lens = cleanLines.map((l) => l.match(/ */)[0].length)
+    const minLen = Math.min(...lens) + 4
+    return '\n' + cleanLines.map((l) => l.substring(minLen)).join('\n') + '\n'
+}


### PR DESCRIPTION
Added a `removeIndent` utility which will calculate the number of extraneous spaces from the tagged template literal of the CSS code, and remove that number of spaces from the indent for each line of CSS.

---

### Before

![image](https://user-images.githubusercontent.com/7415984/177825793-0bc0c767-706c-4279-ab9a-67212f7bf3f6.png)

### After

![image](https://user-images.githubusercontent.com/7415984/177825749-ed71e0b3-aac9-410c-8ad6-0590fa95b5fe.png)
